### PR TITLE
fix: add missing CSS definition for custom-scroll class

### DIFF
--- a/docs/src/app/globals.css
+++ b/docs/src/app/globals.css
@@ -55,3 +55,17 @@ pre,
   -ms-overflow-style: none;  /* IE and Edge */
   scrollbar-width: none;  /* Firefox */
 }
+
+.custom-scroll::-webkit-scrollbar {
+  width: 6px;
+}
+.custom-scroll::-webkit-scrollbar-track {
+  background: transparent;
+}
+.custom-scroll::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.2);
+  border-radius: 3px;
+}
+.custom-scroll::-webkit-scrollbar-thumb:hover {
+  background: rgba(255, 255, 255, 0.3);
+}


### PR DESCRIPTION
## Description
The terminal section in the landing page hero was using a `custom-scroll` class that had no CSS definition, resulting in the default browser scrollbar appearing. This PR adds the missing scrollbar styles to match the project's theme.