### PR TITLE
docs(handler): update next.js config example in error message

### DIFF
--- a/dist/core/handler.js
+++ b/dist/core/handler.js
@@ -341,8 +341,8 @@ function handleStaticFile(path, config) {
         <h3>To fix this:</h3>
         <ol>
           <li><strong>For Next.js:</strong> Add to <code>next.config.js</code>:
-            <pre> 
-  outputFileTracingIncludes: {
+            <pre>serverExternalPackages: ["better-auth-studio"],
+outputFileTracingIncludes: {
     '/api/studio': ['./node_modules/better-auth-studio/dist/public/**/*', './node_modules/better-auth-studio/public/**/*'],
 }</pre>
           </li>

--- a/src/core/handler.ts
+++ b/src/core/handler.ts
@@ -403,8 +403,8 @@ function handleStaticFile(path: string, config: StudioConfig): UniversalResponse
         <h3>To fix this:</h3>
         <ol>
           <li><strong>For Next.js:</strong> Add to <code>next.config.js</code>:
-            <pre> 
-  outputFileTracingIncludes: {
+            <pre>serverExternalPackages: ["better-auth-studio"],
+outputFileTracingIncludes: {
     '/api/studio': ['./node_modules/better-auth-studio/dist/public/**/*', './node_modules/better-auth-studio/public/**/*'],
 }</pre>
           </li>


### PR DESCRIPTION
Add serverExternalPackages to the example configuration to ensure proper static file handling in Next.js applications.

Fix Warning ( Critical dependency: require function is used in a way in which dependencies cannot be statically extracted )