### PR TITLE
fix:  mobile overflow in docs code blocks

### DIFF
--- a/docs/src/app/globals.css
+++ b/docs/src/app/globals.css
@@ -42,9 +42,14 @@ body {
 code,
 pre,
 .font-mono {
-  font-family:
-    var(--font-geist-mono), ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
-    "Liberation Mono", "Courier New", monospace;
+	font-family: var(--font-geist-mono), ui-monospace, SFMono-Regular, Menlo,
+		Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+}
+
+/* Allow long inline code to wrap on small screens without affecting code blocks. */
+:not(pre) > code {
+	overflow-wrap: anywhere;
+	word-break: break-word;
 }
 
 /* Hide scrollbar for Chrome, Safari and Opera */
@@ -142,10 +147,10 @@ pre,
 } */
 
 @keyframes database-animation-path {
-  0% {
-    offset-distance: 0%;
-  }
-  100% {
-    offset-distance: 100%;
-  }
+	0% {
+		offset-distance: 0%;
+	}
+	100% {
+		offset-distance: 100%;
+	}
 }

--- a/docs/src/components/CodeBlock.tsx
+++ b/docs/src/components/CodeBlock.tsx
@@ -43,10 +43,10 @@ export default function CodeBlock({
     </svg>
   );
   return (
-    <div className={`relative group ${className}`}>
+    <div className={`relative group max-w-full ${className}`}>
       <PixelCard variant="code">
-        <div className="flex items-center justify-between gap-3">
-          <code className="text-sm font-mono text-white/90 flex-1 whitespace-pre leading-normal py-0.5">
+        <div className="flex items-center justify-between gap-3 overflow-x-auto thin-scrollbar">
+          <code className="text-sm font-mono text-white/90 flex-1 whitespace-pre leading-normal py-0.5 min-w-0">
             {code}
           </code>
           {showCopy && (

--- a/docs/src/components/SyntaxHighlighter.tsx
+++ b/docs/src/components/SyntaxHighlighter.tsx
@@ -31,7 +31,7 @@ export default function CodeHighlighter({
   };
 
   return (
-    <div className={`relative group w-full ${className}`}>
+    <div className={`relative group w-full max-w-full overflow-x-auto thin-scrollbar ${className}`}>
       <SyntaxHighlighter
         language={language}
         style={oneDark}
@@ -43,7 +43,9 @@ export default function CodeHighlighter({
           fontFamily: "var(--font-geist-mono)",
           lineHeight: "1.5",
           maxHeight: "100%",
-          overflow: "visible",
+          maxWidth: "100%",
+          overflowX: "auto",
+          overflowY: "hidden",
         }}
         codeTagProps={{
           style: {


### PR DESCRIPTION
## Summary
- Prevent long inline code from breaking layout on small screens.
- Enable horizontal scroll for code blocks instead of overflowing the page.
- 
## Affected Pages
- /self-hosting
- /changelog

## How to Test
1. Run docs: `cd docs && pnpm dev`
2. Visit `/self-hosting` and `/changelog`
3. Set viewport width to < 650px
4. Confirm no horizontal overflow and no excessive gaps.

## Screenshots
Before
<img width="322" height="697" alt="image" src="https://github.com/user-attachments/assets/9c0cec5b-349b-4bcb-9065-d7c8e91f8ede" />



After:
<img width="324" height="697" alt="image" src="https://github.com/user-attachments/assets/5eae24dd-bc45-489e-9b27-4eec4d5e6a85" />
