### PR TITLE
feat: add kysely support

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Before using Better Auth Studio, ensure you have:
 
 - **Node.js** (v18 or higher)
 - **A Better Auth project** with a valid `auth.ts` configuration file
-- **Database setup** (Prisma, Drizzle, or SQLite)
+- **Database setup** (Prisma, Drizzle, Kysely, or SQLite)
 
 ## 🔧 Configuration
 
@@ -91,9 +91,10 @@ Better Auth Studio automatically detects and works with:
 
 - **Prisma** (`prismaAdapter`)
 - **Drizzle** (`drizzleAdapter`)
+- **Kysely** (`database: { db, type }`)
 - **SQLite** (`new Database()` from better-sqlite3)
-- **PostgreSQL** (via Prisma or Drizzle)
-- **MySQL** (via Prisma or Drizzle)
+- **PostgreSQL** (via Prisma, Drizzle, or Kysely)
+- **MySQL** (via Prisma, Drizzle, or Kysely)
 
 ### Example Configuration Files
 
@@ -131,6 +132,31 @@ export const auth = betterAuth({
 });
 ```
 
+#### Kysely Setup
+
+```typescript
+// auth.ts
+import { betterAuth } from "better-auth";
+import { Kysely, PostgresDialect } from "kysely";
+import { Pool } from "pg";
+
+const db = new Kysely<any>({
+  dialect: new PostgresDialect({
+    pool: new Pool({
+      connectionString: process.env.DATABASE_URL,
+    }),
+  }),
+});
+
+export const auth = betterAuth({
+  database: {
+    db,
+    type: "postgres", // or "mysql", "sqlite", "mssql"
+  },
+  // ... other config
+});
+```
+
 #### SQLite Setup
 
 ```typescript
@@ -158,7 +184,7 @@ export const auth = betterAuth({
 - **Delete users** - Remove users from the system
 - **Bulk operations** - Seed multiple test users
 - **User details** - View user profiles, and accounts
-- **Last seen** - When events are enabled, the studio injects an optional `lastSeenAt` field on the user model and updates it on each sign-in or session creation. Run your database migration (e.g. `prisma migrate dev` or Drizzle push) to add the `lastSeenAt` column to the user table.
+- **Last seen** - When events are enabled, the studio injects an optional `lastSeenAt` field on the user model and updates it on each sign-in or session creation. Run your database migration (e.g. `prisma migrate dev`, Drizzle push, or a Kysely migration) to add the `lastSeenAt` column to the user table.
 
 ### 🏢 Organization Management
 

--- a/dist/cli.js
+++ b/dist/cli.js
@@ -281,6 +281,12 @@ program
                 else if (content.includes("prismaAdapter")) {
                     databaseInfo = "Prisma";
                 }
+                else if (content.includes("kyselyAdapter") ||
+                    content.includes("Kysely") ||
+                    content.includes('from "kysely"') ||
+                    content.includes("from 'kysely'")) {
+                    databaseInfo = "Kysely";
+                }
                 else if (authConfig.database.adapter && authConfig.database.provider) {
                     const adapter = authConfig.database.adapter;
                     const adapterName = adapter.charAt(0).toUpperCase() + adapter.slice(1);

--- a/dist/core/handler.js
+++ b/dist/core/handler.js
@@ -33,6 +33,7 @@ export async function initializeEventIngestionAndHooks(config) {
                 case "postgres":
                 case "prisma":
                 case "drizzle":
+                case "kysely":
                     try {
                         provider = createPostgresProvider({
                             client: config.events.client,

--- a/dist/providers/events/helpers.d.ts
+++ b/dist/providers/events/helpers.d.ts
@@ -1,9 +1,10 @@
 import type { AuthEvent, EventIngestionProvider } from "../../types/events.js";
+type PostgresProviderClientType = "postgres" | "prisma" | "drizzle" | "kysely";
 export declare function createPostgresProvider(options: {
     client: any;
     tableName?: string;
     schema?: string;
-    clientType?: "postgres" | "prisma" | "drizzle";
+    clientType?: PostgresProviderClientType;
 }): EventIngestionProvider;
 export declare function createSqliteProvider(options: {
     client: any;
@@ -33,3 +34,4 @@ export declare function createStorageProvider(options: {
     adapter: any;
     tableName?: string;
 }): EventIngestionProvider;
+export {};

--- a/dist/providers/events/helpers.js
+++ b/dist/providers/events/helpers.js
@@ -1,3 +1,37 @@
+function isKyselyClient(client, clientType) {
+    const hasExecuteQuery = typeof client?.executeQuery === "function";
+    if (clientType === "kysely") {
+        return hasExecuteQuery;
+    }
+    return hasExecuteQuery && typeof client?.selectFrom === "function";
+}
+function createKyselyCompiledQuery(sql, parameters = []) {
+    return {
+        sql,
+        parameters,
+        queryId: { queryId: `bas_${Date.now()}_${Math.random().toString(36).slice(2)}` },
+    };
+}
+async function executeKyselyQuery(client, query, params = []) {
+    return await client.executeQuery(createKyselyCompiledQuery(query, params));
+}
+function getEventInsertParams(event) {
+    return [
+        event.id,
+        event.type,
+        event.timestamp,
+        event.status || "success",
+        event.userId || null,
+        event.sessionId || null,
+        event.organizationId || null,
+        JSON.stringify(event.metadata || {}),
+        event.ipAddress || null,
+        event.userAgent || null,
+        event.source,
+        event.display?.message || null,
+        event.display?.severity || null,
+    ];
+}
 export function createPostgresProvider(options) {
     const { client, tableName = "auth_events", schema = "public", clientType } = options;
     // Validate client is provided
@@ -18,12 +52,15 @@ export function createPostgresProvider(options) {
     const hasExecuteRaw = client?.$executeRaw;
     const hasExecute = client?.execute;
     const hasUnsafe = actualClient?.unsafe || client?.$client?.unsafe || client?.unsafe;
-    if (!hasQuery && !hasExecuteRaw && !hasExecute && !hasUnsafe) {
+    const hasKysely = isKyselyClient(client, clientType);
+    if (!hasQuery && !hasExecuteRaw && !hasExecute && !hasUnsafe && !hasKysely) {
         const errorMessage = clientType === "prisma"
             ? "Invalid Prisma client. Client must have a `$executeRaw` method."
             : clientType === "drizzle"
                 ? "Invalid Drizzle client. Drizzle instance must wrap a postgres-js (with `unsafe` method) or pg (with `query` method) client."
-                : "Invalid Postgres client. Client must have either a `query` method (pg Pool/Client) or `$executeRaw` method (Prisma client).";
+                : clientType === "kysely"
+                    ? "Invalid Kysely client. Client must have an `executeQuery` method."
+                    : "Invalid Postgres client. Client must have either a `query` method (pg Pool/Client), `$executeRaw` method (Prisma client), or `executeQuery` method (Kysely client).";
         throw new Error(errorMessage);
     }
     // Ensure table exists
@@ -37,6 +74,11 @@ export function createPostgresProvider(options) {
                 // Prisma client
                 executeQuery = async (query) => {
                     return await client.$executeRawUnsafe(query);
+                };
+            }
+            else if (hasKysely) {
+                executeQuery = async (query) => {
+                    return await executeKyselyQuery(client, query);
                 };
             }
             else if (clientType === "drizzle") {
@@ -69,7 +111,7 @@ export function createPostgresProvider(options) {
                 };
             }
             else {
-                throw new Error(`Postgres client doesn't support $executeRaw or query method. Available properties: ${Object.keys(client).join(", ")}`);
+                throw new Error(`Postgres client doesn't support $executeRaw, executeQuery, or query method. Available properties: ${Object.keys(client).join(", ")}`);
             }
             // Use CREATE TABLE IF NOT EXISTS (simpler and more reliable)
             const createTableQuery = `
@@ -141,7 +183,32 @@ export function createPostgresProvider(options) {
     return {
         async ingest(event) {
             await ensureTableSync();
-            if (clientType === "prisma" || client.$executeRaw) {
+            if (hasKysely) {
+                try {
+                    await executeKyselyQuery(client, `INSERT INTO ${schema}.${tableName}
+             (id, type, timestamp, status, user_id, session_id, organization_id, metadata, ip_address, user_agent, source, display_message, display_severity)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)`, getEventInsertParams(event));
+                }
+                catch (error) {
+                    console.error(`Failed to insert event (${event.type}) into ${schema}.${tableName}:`, error);
+                    if (error.code === "42P01") {
+                        tableEnsured = false;
+                        await ensureTableSync();
+                        try {
+                            await executeKyselyQuery(client, `INSERT INTO ${schema}.${tableName}
+                 (id, type, timestamp, status, user_id, session_id, organization_id, metadata, ip_address, user_agent, source, display_message, display_severity)
+                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)`, getEventInsertParams(event));
+                            return;
+                        }
+                        catch (retryError) {
+                            console.error(`Retry after table creation also failed:`, retryError);
+                            throw retryError;
+                        }
+                    }
+                    throw error;
+                }
+            }
+            else if (clientType === "prisma" || client.$executeRaw) {
                 const query = `
           INSERT INTO ${schema}.${tableName} 
           (id, type, timestamp, status, user_id, session_id, organization_id, metadata, ip_address, user_agent, source, display_message, display_severity)
@@ -176,7 +243,7 @@ export function createPostgresProvider(options) {
                 if (useUnsafe) {
                     // postgres-js client - use unsafe() for raw SQL
                     const query = `
-            INSERT INTO ${schema}.${tableName} 
+            INSERT INTO ${schema}.${tableName}
             (id, type, timestamp, status, user_id, session_id, organization_id, metadata, ip_address, user_agent, source, display_message, display_severity)
             VALUES ('${event.id}'::uuid, '${event.type}', '${event.timestamp.toISOString()}', '${event.status || "success"}', ${event.userId ? `'${event.userId.replace(/'/g, "''")}'` : "NULL"}, ${event.sessionId ? `'${event.sessionId.replace(/'/g, "''")}'` : "NULL"}, ${event.organizationId ? `'${event.organizationId.replace(/'/g, "''")}'` : "NULL"}, '${JSON.stringify(event.metadata || {}).replace(/'/g, "''")}'::jsonb, ${event.ipAddress ? `'${event.ipAddress.replace(/'/g, "''")}'` : "NULL"}, ${event.userAgent ? `'${event.userAgent.replace(/'/g, "''")}'` : "NULL"}, '${event.source}', ${event.display?.message ? `'${event.display.message.replace(/'/g, "''")}'` : "NULL"}, ${event.display?.severity ? `'${event.display.severity}'` : "NULL"})
           `;
@@ -205,21 +272,7 @@ export function createPostgresProvider(options) {
                     try {
                         await queryClient.query(`INSERT INTO ${schema}.${tableName} 
                (id, type, timestamp, status, user_id, session_id, organization_id, metadata, ip_address, user_agent, source, display_message, display_severity)
-               VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)`, [
-                            event.id,
-                            event.type,
-                            event.timestamp,
-                            event.status || "success",
-                            event.userId || null,
-                            event.sessionId || null,
-                            event.organizationId || null,
-                            JSON.stringify(event.metadata || {}),
-                            event.ipAddress || null,
-                            event.userAgent || null,
-                            event.source,
-                            event.display?.message || null,
-                            event.display?.severity || null,
-                        ]);
+               VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)`, [...getEventInsertParams(event)]);
                     }
                     catch (error) {
                         console.error(`Failed to insert event (${event.type}) into ${schema}.${tableName}:`, error);
@@ -229,21 +282,7 @@ export function createPostgresProvider(options) {
                             try {
                                 await queryClient.query(`INSERT INTO ${schema}.${tableName} 
                    (id, type, timestamp, status, user_id, session_id, organization_id, metadata, ip_address, user_agent, source, display_message, display_severity)
-                   VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)`, [
-                                    event.id,
-                                    event.type,
-                                    event.timestamp,
-                                    event.status || "success",
-                                    event.userId || null,
-                                    event.sessionId || null,
-                                    event.organizationId || null,
-                                    JSON.stringify(event.metadata || {}),
-                                    event.ipAddress || null,
-                                    event.userAgent || null,
-                                    event.source,
-                                    event.display?.message || null,
-                                    event.display?.severity || null,
-                                ]);
+                   VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)`, [...getEventInsertParams(event)]);
                                 return;
                             }
                             catch (retryError) {
@@ -271,7 +310,34 @@ export function createPostgresProvider(options) {
                 return;
             await ensureTableSync();
             // Support Prisma client ($executeRaw), Drizzle instance, or standard pg client (query)
-            if (clientType === "prisma" || client.$executeRaw) {
+            if (hasKysely) {
+                const PARAMS_PER_EVENT = 13;
+                const MAX_PARAMS = 65535;
+                const CHUNK_SIZE = Math.floor(MAX_PARAMS / PARAMS_PER_EVENT) - 1;
+                for (let chunkStart = 0; chunkStart < events.length; chunkStart += CHUNK_SIZE) {
+                    const chunk = events.slice(chunkStart, chunkStart + CHUNK_SIZE);
+                    const values = chunk
+                        .map((_, i) => {
+                        const base = i * PARAMS_PER_EVENT;
+                        return `($${base + 1}, $${base + 2}, $${base + 3}, $${base + 4}, $${base + 5}, $${base + 6}, $${base + 7}, $${base + 8}, $${base + 9}, $${base + 10}, $${base + 11}, $${base + 12}, $${base + 13})`;
+                    })
+                        .join(", ");
+                    const query = `
+            INSERT INTO ${schema}.${tableName}
+            (id, type, timestamp, status, user_id, session_id, organization_id, metadata, ip_address, user_agent, source, display_message, display_severity)
+            VALUES ${values}
+          `;
+                    const params = chunk.flatMap((event) => getEventInsertParams(event));
+                    try {
+                        await executeKyselyQuery(client, query, params);
+                    }
+                    catch (error) {
+                        console.error(`Failed to insert batch chunk (${chunk.length} events) into ${schema}.${tableName}:`, error);
+                        throw error;
+                    }
+                }
+            }
+            else if (clientType === "prisma" || client.$executeRaw) {
                 // Prisma client - use $executeRawUnsafe for batch inserts
                 const CHUNK_SIZE = 500; // Reasonable chunk size for string-based queries
                 for (let i = 0; i < events.length; i += CHUNK_SIZE) {
@@ -339,21 +405,7 @@ export function createPostgresProvider(options) {
               (id, type, timestamp, status, user_id, session_id, organization_id, metadata, ip_address, user_agent, source, display_message, display_severity)
               VALUES ${values}
             `;
-                        const params = chunk.flatMap((event) => [
-                            event.id,
-                            event.type,
-                            event.timestamp,
-                            event.status || "success",
-                            event.userId || null,
-                            event.sessionId || null,
-                            event.organizationId || null,
-                            JSON.stringify(event.metadata || {}),
-                            event.ipAddress || null,
-                            event.userAgent || null,
-                            event.source,
-                            event.display?.message || null,
-                            event.display?.severity || null,
-                        ]);
+                        const params = chunk.flatMap((event) => getEventInsertParams(event));
                         try {
                             await batchQueryClient.query(query, params);
                         }
@@ -401,6 +453,11 @@ export function createPostgresProvider(options) {
                     }
                 };
             }
+            else if (hasKysely) {
+                queryFn = async (query, params) => {
+                    return await executeKyselyQuery(client, query, params || []);
+                };
+            }
             else if (client.query) {
                 // Standard pg client (Pool or Client)
                 queryFn = async (query, params) => {
@@ -426,6 +483,9 @@ export function createPostgresProvider(options) {
                         .replace("$1", `'${schema}'`)
                         .replace("$2", `'${tableName}'`);
                     checkResult = await client.$queryRawUnsafe(prismaQuery);
+                }
+                else if (hasKysely) {
+                    checkResult = await queryFn(checkTableQuery, [schema, tableName]);
                 }
                 else {
                     // Standard pg client

--- a/dist/types/handler.d.ts
+++ b/dist/types/handler.d.ts
@@ -124,7 +124,7 @@ export type StudioConfig = {
         tableName?: string;
         provider?: EventIngestionProvider;
         client?: any;
-        clientType?: "postgres" | "prisma" | "drizzle" | "clickhouse" | "https" | "custom" | "sqlite" | "node-sqlite";
+        clientType?: "postgres" | "prisma" | "drizzle" | "kysely" | "clickhouse" | "https" | "custom" | "sqlite" | "node-sqlite";
         include?: AuthEventType[];
         exclude?: AuthEventType[];
         batchSize?: number;

--- a/dist/utils/database-detection.js
+++ b/dist/utils/database-detection.js
@@ -1,7 +1,8 @@
-import { getPackageVersion } from "./package-json.js";
+import { getDirectPackageVersion, getPackageVersion } from "./package-json.js";
 const DATABASES = {
     "drizzle-orm": "drizzle",
     "@prisma/client": "prisma",
+    kysely: "kysely",
     mongoose: "mongodb",
     mongodb: "mongodb",
     pg: "postgresql",
@@ -16,6 +17,7 @@ const _DATABASE_DIALECTS = {
     mariadb: ["mariadb"],
     sqlite: ["sqlite3", "better-sqlite3"],
     prisma: ["@prisma/client"],
+    kysely: ["kysely"],
     mongodb: ["mongoose", "mongodb"],
     drizzle: ["drizzle-orm"],
 };
@@ -26,7 +28,7 @@ const _DATABASE_DIALECTS = {
  */
 export async function detectDatabase(cwd) {
     for (const [pkg, name] of Object.entries(DATABASES)) {
-        const version = await getPackageVersion(pkg, cwd);
+        const version = pkg === "kysely" ? getDirectPackageVersion(pkg, cwd) : await getPackageVersion(pkg, cwd);
         if (version)
             return { name, version };
     }
@@ -79,6 +81,14 @@ export async function detectDatabaseWithDialect(cwd) {
             adapter = "drizzle";
             break;
         }
+        case "kysely": {
+            const kyselyDialect = await detectKyselyDialect(cwd);
+            if (kyselyDialect) {
+                dialect = kyselyDialect;
+            }
+            adapter = "kysely";
+            break;
+        }
     }
     return {
         name: detection.name,
@@ -118,6 +128,26 @@ async function detectDrizzleDialect(cwd) {
             if (version)
                 return dialect;
         }
+        catch { }
+    }
+    return undefined;
+}
+async function detectKyselyDialect(cwd) {
+    const kyselyDrivers = [
+        { pkg: "pg", dialect: "postgresql" },
+        { pkg: "postgres", dialect: "postgresql" },
+        { pkg: "mysql2", dialect: "mysql" },
+        { pkg: "better-sqlite3", dialect: "sqlite" },
+        { pkg: "sqlite3", dialect: "sqlite" },
+        { pkg: "tedious", dialect: "mssql" },
+        { pkg: "mssql", dialect: "mssql" },
+    ];
+    for (const { pkg, dialect } of kyselyDrivers) {
+        try {
+            const version = await getPackageVersion(pkg, cwd);
+            if (version)
+                return dialect;
+        }
         catch (_error) { }
     }
     return undefined;
@@ -130,7 +160,7 @@ async function detectDrizzleDialect(cwd) {
 export async function detectAllDatabases(cwd) {
     const results = [];
     for (const [pkg, name] of Object.entries(DATABASES)) {
-        const version = await getPackageVersion(pkg, cwd);
+        const version = pkg === "kysely" ? getDirectPackageVersion(pkg, cwd) : await getPackageVersion(pkg, cwd);
         if (version) {
             const detection = await detectDatabaseWithDialect(cwd);
             if (detection && detection.name === name) {

--- a/dist/utils/event-ingestion.js
+++ b/dist/utils/event-ingestion.js
@@ -25,6 +25,7 @@ export function initializeEventIngestion(eventsConfig) {
             case "postgres":
             case "prisma":
             case "drizzle":
+            case "kysely":
                 try {
                     provider = createPostgresProvider({
                         client: eventsConfig.client,

--- a/dist/utils/hook-injector.js
+++ b/dist/utils/hook-injector.js
@@ -967,6 +967,7 @@ function createEventIngestionPlugin(eventsConfig) {
                             case "postgres":
                             case "prisma":
                             case "drizzle":
+                            case "kysely":
                                 provider = createPostgresProvider({
                                     client: capturedConfig.client,
                                     tableName: capturedConfig.tableName,

--- a/dist/utils/package-json.d.ts
+++ b/dist/utils/package-json.d.ts
@@ -5,3 +5,4 @@
  * @returns The version string if found, undefined otherwise
  */
 export declare function getPackageVersion(packageName: string, cwd?: string): Promise<string | undefined>;
+export declare function getDirectPackageVersion(packageName: string, cwd?: string): string | undefined;

--- a/dist/utils/package-json.js
+++ b/dist/utils/package-json.js
@@ -60,3 +60,24 @@ export async function getPackageVersion(packageName, cwd) {
         return undefined;
     }
 }
+export function getDirectPackageVersion(packageName, cwd) {
+    const searchDir = cwd || process.cwd();
+    const projectRoot = findProjectRoot(searchDir);
+    const packageJsonPaths = Array.from(new Set([join(searchDir, "package.json"), join(projectRoot, "package.json")]));
+    for (const packageJsonPath of packageJsonPaths) {
+        if (!existsSync(packageJsonPath)) {
+            continue;
+        }
+        try {
+            const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf-8"));
+            const version = packageJson.dependencies?.[packageName] ||
+                packageJson.devDependencies?.[packageName] ||
+                packageJson.peerDependencies?.[packageName];
+            if (version) {
+                return version.replace(/[\^~]/, "");
+            }
+        }
+        catch { }
+    }
+    return undefined;
+}

--- a/docs/src/app/installation/page.tsx
+++ b/docs/src/app/installation/page.tsx
@@ -390,7 +390,7 @@ export default function Installation() {
               </li>
               <li className="flex items-start">
                 <span className="text-white/50 mr-3">•</span>
-                <strong>Database setup</strong> (Prisma, Drizzle, or SQLite)
+                <strong>Database setup</strong> (Prisma, Drizzle, Kysely, or SQLite)
               </li>
             </ul>
           </PixelCard>
@@ -429,17 +429,23 @@ export default function Installation() {
                 </div>
                 <div className="flex items-center text-sm font-light tracking-tight text-white/70">
                   <span className="text-white/50 mr-3">→</span>
+                  <strong>Kysely</strong> (
+                  <code className="bg-white/10 px-1 text-white/90">database: {"{ db, type }"}</code>
+                  )
+                </div>
+                <div className="flex items-center text-sm font-light tracking-tight text-white/70">
+                  <span className="text-white/50 mr-3">→</span>
                   <strong>SQLite</strong> (
                   <code className="bg-white/10 px-1 text-white/90">new Database()</code> from
                   better-sqlite3)
                 </div>
                 <div className="flex items-center text-sm font-light tracking-tight text-white/70">
                   <span className="text-white/50 mr-3">→</span>
-                  <strong>PostgreSQL</strong> (via Prisma or Drizzle)
+                  <strong>PostgreSQL</strong> (via Prisma, Drizzle, or Kysely)
                 </div>
                 <div className="flex items-center text-sm font-light tracking-tight text-white/70">
                   <span className="text-white/50 mr-3">→</span>
-                  <strong>MySQL</strong> (via Prisma or Drizzle)
+                  <strong>MySQL</strong> (via Prisma, Drizzle, or Kysely)
                 </div>
               </div>
             </PixelCard>
@@ -495,6 +501,35 @@ export const auth = betterAuth({
   database: drizzleAdapter(db, {
     provider: "pg", // or "mysql", "sqlite"
   }),
+  // ... other config
+});`}
+                    language="typescript"
+                  />
+                </PixelCard>
+              </div>
+
+              <div className="mb-6">
+                <h4 className="font-light tracking-tight mb-3 text-white">Kysely Setup</h4>
+                <PixelCard variant="code">
+                  <CodeHighlighter
+                    code={`// auth.ts
+import { betterAuth } from "better-auth";
+import { Kysely, PostgresDialect } from "kysely";
+import { Pool } from "pg";
+
+const db = new Kysely<any>({
+  dialect: new PostgresDialect({
+    pool: new Pool({
+      connectionString: process.env.DATABASE_URL,
+    }),
+  }),
+});
+
+export const auth = betterAuth({
+  database: {
+    db,
+    type: "postgres", // or "mysql", "sqlite", "mssql"
+  },
   // ... other config
 });`}
                     language="typescript"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -357,6 +357,13 @@ program
             databaseInfo = "Drizzle";
           } else if (content.includes("prismaAdapter")) {
             databaseInfo = "Prisma";
+          } else if (
+            content.includes("kyselyAdapter") ||
+            content.includes("Kysely") ||
+            content.includes('from "kysely"') ||
+            content.includes("from 'kysely'")
+          ) {
+            databaseInfo = "Kysely";
           } else if (authConfig.database.adapter && authConfig.database.provider) {
             const adapter = authConfig.database.adapter;
             const adapterName = adapter.charAt(0).toUpperCase() + adapter.slice(1);

--- a/src/core/handler.ts
+++ b/src/core/handler.ts
@@ -51,6 +51,7 @@ export async function initializeEventIngestionAndHooks(config: StudioConfig): Pr
         case "postgres":
         case "prisma":
         case "drizzle":
+        case "kysely":
           try {
             provider = createPostgresProvider({
               client: config.events.client,

--- a/src/providers/events/helpers.ts
+++ b/src/providers/events/helpers.ts
@@ -6,11 +6,58 @@ import type {
   EventQueryResult,
 } from "../../types/events.js";
 
+type PostgresProviderClientType = "postgres" | "prisma" | "drizzle" | "kysely";
+
+type KyselyCompiledQuery = {
+  sql: string;
+  parameters: ReadonlyArray<unknown>;
+  queryId: { queryId: string };
+};
+
+function isKyselyClient(client: any, clientType?: PostgresProviderClientType): boolean {
+  const hasExecuteQuery = typeof client?.executeQuery === "function";
+  if (clientType === "kysely") {
+    return hasExecuteQuery;
+  }
+
+  return hasExecuteQuery && typeof client?.selectFrom === "function";
+}
+
+function createKyselyCompiledQuery(sql: string, parameters: unknown[] = []): KyselyCompiledQuery {
+  return {
+    sql,
+    parameters,
+    queryId: { queryId: `bas_${Date.now()}_${Math.random().toString(36).slice(2)}` },
+  };
+}
+
+async function executeKyselyQuery(client: any, query: string, params: unknown[] = []) {
+  return await client.executeQuery(createKyselyCompiledQuery(query, params));
+}
+
+function getEventInsertParams(event: AuthEvent): unknown[] {
+  return [
+    event.id,
+    event.type,
+    event.timestamp,
+    event.status || "success",
+    event.userId || null,
+    event.sessionId || null,
+    event.organizationId || null,
+    JSON.stringify(event.metadata || {}),
+    event.ipAddress || null,
+    event.userAgent || null,
+    event.source,
+    event.display?.message || null,
+    event.display?.severity || null,
+  ];
+}
+
 export function createPostgresProvider(options: {
   client: any;
   tableName?: string;
   schema?: string;
-  clientType?: "postgres" | "prisma" | "drizzle";
+  clientType?: PostgresProviderClientType;
 }): EventIngestionProvider {
   const { client, tableName = "auth_events", schema = "public", clientType } = options;
 
@@ -35,14 +82,17 @@ export function createPostgresProvider(options: {
   const hasExecuteRaw = client?.$executeRaw;
   const hasExecute = client?.execute;
   const hasUnsafe = actualClient?.unsafe || client?.$client?.unsafe || client?.unsafe;
+  const hasKysely = isKyselyClient(client, clientType);
 
-  if (!hasQuery && !hasExecuteRaw && !hasExecute && !hasUnsafe) {
+  if (!hasQuery && !hasExecuteRaw && !hasExecute && !hasUnsafe && !hasKysely) {
     const errorMessage =
       clientType === "prisma"
         ? "Invalid Prisma client. Client must have a `$executeRaw` method."
         : clientType === "drizzle"
           ? "Invalid Drizzle client. Drizzle instance must wrap a postgres-js (with `unsafe` method) or pg (with `query` method) client."
-          : "Invalid Postgres client. Client must have either a `query` method (pg Pool/Client) or `$executeRaw` method (Prisma client).";
+          : clientType === "kysely"
+            ? "Invalid Kysely client. Client must have an `executeQuery` method."
+            : "Invalid Postgres client. Client must have either a `query` method (pg Pool/Client), `$executeRaw` method (Prisma client), or `executeQuery` method (Kysely client).";
     throw new Error(errorMessage);
   }
 
@@ -58,6 +108,10 @@ export function createPostgresProvider(options: {
         // Prisma client
         executeQuery = async (query: string) => {
           return await client.$executeRawUnsafe(query);
+        };
+      } else if (hasKysely) {
+        executeQuery = async (query: string) => {
+          return await executeKyselyQuery(client, query);
         };
       } else if (clientType === "drizzle") {
         // Drizzle client - use $client which exposes the underlying client
@@ -87,7 +141,7 @@ export function createPostgresProvider(options: {
         };
       } else {
         throw new Error(
-          `Postgres client doesn't support $executeRaw or query method. Available properties: ${Object.keys(client).join(", ")}`,
+          `Postgres client doesn't support $executeRaw, executeQuery, or query method. Available properties: ${Object.keys(client).join(", ")}`,
         );
       }
 
@@ -168,7 +222,40 @@ export function createPostgresProvider(options: {
     async ingest(event: AuthEvent) {
       await ensureTableSync();
 
-      if (clientType === "prisma" || client.$executeRaw) {
+      if (hasKysely) {
+        try {
+          await executeKyselyQuery(
+            client,
+            `INSERT INTO ${schema}.${tableName}
+             (id, type, timestamp, status, user_id, session_id, organization_id, metadata, ip_address, user_agent, source, display_message, display_severity)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)`,
+            getEventInsertParams(event),
+          );
+        } catch (error: any) {
+          console.error(
+            `Failed to insert event (${event.type}) into ${schema}.${tableName}:`,
+            error,
+          );
+          if (error.code === "42P01") {
+            tableEnsured = false;
+            await ensureTableSync();
+            try {
+              await executeKyselyQuery(
+                client,
+                `INSERT INTO ${schema}.${tableName}
+                 (id, type, timestamp, status, user_id, session_id, organization_id, metadata, ip_address, user_agent, source, display_message, display_severity)
+                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)`,
+                getEventInsertParams(event),
+              );
+              return;
+            } catch (retryError: any) {
+              console.error(`Retry after table creation also failed:`, retryError);
+              throw retryError;
+            }
+          }
+          throw error;
+        }
+      } else if (clientType === "prisma" || client.$executeRaw) {
         const query = `
           INSERT INTO ${schema}.${tableName} 
           (id, type, timestamp, status, user_id, session_id, organization_id, metadata, ip_address, user_agent, source, display_message, display_severity)
@@ -206,7 +293,7 @@ export function createPostgresProvider(options: {
         if (useUnsafe) {
           // postgres-js client - use unsafe() for raw SQL
           const query = `
-            INSERT INTO ${schema}.${tableName} 
+            INSERT INTO ${schema}.${tableName}
             (id, type, timestamp, status, user_id, session_id, organization_id, metadata, ip_address, user_agent, source, display_message, display_severity)
             VALUES ('${event.id}'::uuid, '${event.type}', '${event.timestamp.toISOString()}', '${event.status || "success"}', ${event.userId ? `'${event.userId.replace(/'/g, "''")}'` : "NULL"}, ${event.sessionId ? `'${event.sessionId.replace(/'/g, "''")}'` : "NULL"}, ${event.organizationId ? `'${event.organizationId.replace(/'/g, "''")}'` : "NULL"}, '${JSON.stringify(event.metadata || {}).replace(/'/g, "''")}'::jsonb, ${event.ipAddress ? `'${event.ipAddress.replace(/'/g, "''")}'` : "NULL"}, ${event.userAgent ? `'${event.userAgent.replace(/'/g, "''")}'` : "NULL"}, '${event.source}', ${event.display?.message ? `'${event.display.message.replace(/'/g, "''")}'` : "NULL"}, ${event.display?.severity ? `'${event.display.severity}'` : "NULL"})
           `;
@@ -237,21 +324,7 @@ export function createPostgresProvider(options: {
               `INSERT INTO ${schema}.${tableName} 
                (id, type, timestamp, status, user_id, session_id, organization_id, metadata, ip_address, user_agent, source, display_message, display_severity)
                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)`,
-              [
-                event.id,
-                event.type,
-                event.timestamp,
-                event.status || "success",
-                event.userId || null,
-                event.sessionId || null,
-                event.organizationId || null,
-                JSON.stringify(event.metadata || {}),
-                event.ipAddress || null,
-                event.userAgent || null,
-                event.source,
-                event.display?.message || null,
-                event.display?.severity || null,
-              ],
+              [...getEventInsertParams(event)],
             );
           } catch (error: any) {
             console.error(
@@ -266,21 +339,7 @@ export function createPostgresProvider(options: {
                   `INSERT INTO ${schema}.${tableName} 
                    (id, type, timestamp, status, user_id, session_id, organization_id, metadata, ip_address, user_agent, source, display_message, display_severity)
                    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)`,
-                  [
-                    event.id,
-                    event.type,
-                    event.timestamp,
-                    event.status || "success",
-                    event.userId || null,
-                    event.sessionId || null,
-                    event.organizationId || null,
-                    JSON.stringify(event.metadata || {}),
-                    event.ipAddress || null,
-                    event.userAgent || null,
-                    event.source,
-                    event.display?.message || null,
-                    event.display?.severity || null,
-                  ],
+                  [...getEventInsertParams(event)],
                 );
                 return;
               } catch (retryError: any) {
@@ -315,7 +374,40 @@ export function createPostgresProvider(options: {
       await ensureTableSync();
 
       // Support Prisma client ($executeRaw), Drizzle instance, or standard pg client (query)
-      if (clientType === "prisma" || client.$executeRaw) {
+      if (hasKysely) {
+        const PARAMS_PER_EVENT = 13;
+        const MAX_PARAMS = 65535;
+        const CHUNK_SIZE = Math.floor(MAX_PARAMS / PARAMS_PER_EVENT) - 1;
+
+        for (let chunkStart = 0; chunkStart < events.length; chunkStart += CHUNK_SIZE) {
+          const chunk = events.slice(chunkStart, chunkStart + CHUNK_SIZE);
+
+          const values = chunk
+            .map((_, i) => {
+              const base = i * PARAMS_PER_EVENT;
+              return `($${base + 1}, $${base + 2}, $${base + 3}, $${base + 4}, $${base + 5}, $${base + 6}, $${base + 7}, $${base + 8}, $${base + 9}, $${base + 10}, $${base + 11}, $${base + 12}, $${base + 13})`;
+            })
+            .join(", ");
+
+          const query = `
+            INSERT INTO ${schema}.${tableName}
+            (id, type, timestamp, status, user_id, session_id, organization_id, metadata, ip_address, user_agent, source, display_message, display_severity)
+            VALUES ${values}
+          `;
+
+          const params = chunk.flatMap((event) => getEventInsertParams(event));
+
+          try {
+            await executeKyselyQuery(client, query, params);
+          } catch (error: any) {
+            console.error(
+              `Failed to insert batch chunk (${chunk.length} events) into ${schema}.${tableName}:`,
+              error,
+            );
+            throw error;
+          }
+        }
+      } else if (clientType === "prisma" || client.$executeRaw) {
         // Prisma client - use $executeRawUnsafe for batch inserts
         const CHUNK_SIZE = 500; // Reasonable chunk size for string-based queries
         for (let i = 0; i < events.length; i += CHUNK_SIZE) {
@@ -396,21 +488,7 @@ export function createPostgresProvider(options: {
               VALUES ${values}
             `;
 
-            const params = chunk.flatMap((event) => [
-              event.id,
-              event.type,
-              event.timestamp,
-              event.status || "success",
-              event.userId || null,
-              event.sessionId || null,
-              event.organizationId || null,
-              JSON.stringify(event.metadata || {}),
-              event.ipAddress || null,
-              event.userAgent || null,
-              event.source,
-              event.display?.message || null,
-              event.display?.severity || null,
-            ]);
+            const params = chunk.flatMap((event) => getEventInsertParams(event));
 
             try {
               await batchQueryClient.query(query, params);
@@ -471,6 +549,10 @@ export function createPostgresProvider(options: {
             return await client.$queryRawUnsafe(query);
           }
         };
+      } else if (hasKysely) {
+        queryFn = async (query: string, params?: any[]) => {
+          return await executeKyselyQuery(client, query, params || []);
+        };
       } else if (client.query) {
         // Standard pg client (Pool or Client)
         queryFn = async (query: string, params?: any[]) => {
@@ -496,6 +578,8 @@ export function createPostgresProvider(options: {
             .replace("$1", `'${schema}'`)
             .replace("$2", `'${tableName}'`);
           checkResult = await client.$queryRawUnsafe(prismaQuery);
+        } else if (hasKysely) {
+          checkResult = await queryFn(checkTableQuery, [schema, tableName]);
         } else {
           // Standard pg client
           checkResult = await queryFn(checkTableQuery, [schema, tableName]);

--- a/src/types/handler.ts
+++ b/src/types/handler.ts
@@ -169,6 +169,7 @@ export type StudioConfig = {
       | "postgres"
       | "prisma"
       | "drizzle"
+      | "kysely"
       | "clickhouse"
       | "https"
       | "custom"

--- a/src/utils/database-detection.ts
+++ b/src/utils/database-detection.ts
@@ -1,9 +1,10 @@
 import type { DatabaseDetectionResult, DetectionInfo } from "../types";
-import { getPackageVersion } from "./package-json.js";
+import { getDirectPackageVersion, getPackageVersion } from "./package-json.js";
 
 const DATABASES: Record<string, string> = {
   "drizzle-orm": "drizzle",
   "@prisma/client": "prisma",
+  kysely: "kysely",
   mongoose: "mongodb",
   mongodb: "mongodb",
   pg: "postgresql",
@@ -19,6 +20,7 @@ const _DATABASE_DIALECTS: Record<string, string[]> = {
   mariadb: ["mariadb"],
   sqlite: ["sqlite3", "better-sqlite3"],
   prisma: ["@prisma/client"],
+  kysely: ["kysely"],
   mongodb: ["mongoose", "mongodb"],
   drizzle: ["drizzle-orm"],
 };
@@ -30,7 +32,8 @@ const _DATABASE_DIALECTS: Record<string, string[]> = {
  */
 export async function detectDatabase(cwd?: string): Promise<DetectionInfo | undefined> {
   for (const [pkg, name] of Object.entries(DATABASES)) {
-    const version = await getPackageVersion(pkg, cwd);
+    const version =
+      pkg === "kysely" ? getDirectPackageVersion(pkg, cwd) : await getPackageVersion(pkg, cwd);
     if (version) return { name, version };
   }
   return undefined;
@@ -86,6 +89,14 @@ export async function detectDatabaseWithDialect(
       adapter = "drizzle";
       break;
     }
+    case "kysely": {
+      const kyselyDialect = await detectKyselyDialect(cwd);
+      if (kyselyDialect) {
+        dialect = kyselyDialect;
+      }
+      adapter = "kysely";
+      break;
+    }
   }
 
   return {
@@ -128,6 +139,27 @@ async function detectDrizzleDialect(cwd?: string): Promise<string | undefined> {
     try {
       const version = await getPackageVersion(pkg, cwd);
       if (version) return dialect;
+    } catch {}
+  }
+
+  return undefined;
+}
+
+async function detectKyselyDialect(cwd?: string): Promise<string | undefined> {
+  const kyselyDrivers = [
+    { pkg: "pg", dialect: "postgresql" },
+    { pkg: "postgres", dialect: "postgresql" },
+    { pkg: "mysql2", dialect: "mysql" },
+    { pkg: "better-sqlite3", dialect: "sqlite" },
+    { pkg: "sqlite3", dialect: "sqlite" },
+    { pkg: "tedious", dialect: "mssql" },
+    { pkg: "mssql", dialect: "mssql" },
+  ];
+
+  for (const { pkg, dialect } of kyselyDrivers) {
+    try {
+      const version = await getPackageVersion(pkg, cwd);
+      if (version) return dialect;
     } catch (_error) {}
   }
 
@@ -143,7 +175,8 @@ export async function detectAllDatabases(cwd?: string): Promise<DatabaseDetectio
   const results: DatabaseDetectionResult[] = [];
 
   for (const [pkg, name] of Object.entries(DATABASES)) {
-    const version = await getPackageVersion(pkg, cwd);
+    const version =
+      pkg === "kysely" ? getDirectPackageVersion(pkg, cwd) : await getPackageVersion(pkg, cwd);
     if (version) {
       const detection = await detectDatabaseWithDialect(cwd);
       if (detection && detection.name === name) {

--- a/src/utils/event-ingestion.ts
+++ b/src/utils/event-ingestion.ts
@@ -43,6 +43,7 @@ export function initializeEventIngestion(eventsConfig: StudioConfig["events"]): 
       case "postgres":
       case "prisma":
       case "drizzle":
+      case "kysely":
         try {
           provider = createPostgresProvider({
             client: eventsConfig.client,

--- a/src/utils/hook-injector.ts
+++ b/src/utils/hook-injector.ts
@@ -1194,6 +1194,7 @@ function createEventIngestionPlugin(eventsConfig: StudioConfig["events"]): any {
               case "postgres":
               case "prisma":
               case "drizzle":
+              case "kysely":
                 provider = createPostgresProvider({
                   client: capturedConfig.client,
                   tableName: capturedConfig.tableName,

--- a/src/utils/package-json.ts
+++ b/src/utils/package-json.ts
@@ -70,3 +70,31 @@ export async function getPackageVersion(
     return undefined;
   }
 }
+
+export function getDirectPackageVersion(packageName: string, cwd?: string): string | undefined {
+  const searchDir = cwd || process.cwd();
+  const projectRoot = findProjectRoot(searchDir);
+  const packageJsonPaths = Array.from(
+    new Set([join(searchDir, "package.json"), join(projectRoot, "package.json")]),
+  );
+
+  for (const packageJsonPath of packageJsonPaths) {
+    if (!existsSync(packageJsonPath)) {
+      continue;
+    }
+
+    try {
+      const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf-8"));
+      const version =
+        packageJson.dependencies?.[packageName] ||
+        packageJson.devDependencies?.[packageName] ||
+        packageJson.peerDependencies?.[packageName];
+
+      if (version) {
+        return version.replace(/[\^~]/, "");
+      }
+    } catch {}
+  }
+
+  return undefined;
+}

--- a/tests/database-detection.test.ts
+++ b/tests/database-detection.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { detectDatabase, detectDatabaseWithDialect } from "../src/utils/database-detection";
+
+describe("Database detection", () => {
+  const testDir = join(process.cwd(), ".test-temp-db-detection");
+
+  beforeEach(() => {
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+    mkdirSync(testDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it("detects direct Kysely dependencies", async () => {
+    writeFileSync(
+      join(testDir, "package.json"),
+      JSON.stringify({
+        dependencies: {
+          kysely: "^0.28.8",
+        },
+      }),
+    );
+
+    await expect(detectDatabase(testDir)).resolves.toEqual({
+      name: "kysely",
+      version: "0.28.8",
+    });
+  });
+
+  it("detects Kysely's Postgres dialect from installed drivers", async () => {
+    writeFileSync(
+      join(testDir, "package.json"),
+      JSON.stringify({
+        dependencies: {
+          kysely: "^0.28.8",
+          pg: "^8.13.0",
+        },
+      }),
+    );
+
+    await expect(detectDatabaseWithDialect(testDir)).resolves.toEqual({
+      name: "kysely",
+      version: "0.28.8",
+      dialect: "postgresql",
+      adapter: "kysely",
+    });
+  });
+});

--- a/tests/events.test.ts
+++ b/tests/events.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi } from "vitest";
+import { createPostgresProvider } from "../src/providers/events/helpers";
+import type { AuthEvent } from "../src/types/events";
+
+describe("Event providers", () => {
+  it("supports Kysely clients for Postgres event ingestion", async () => {
+    const executeQuery = vi.fn(async (compiledQuery: { sql: string; parameters: unknown[] }) => {
+      if (compiledQuery.sql.includes("SELECT EXISTS")) {
+        return { rows: [{ exists: true }] };
+      }
+
+      return { rows: [] };
+    });
+
+    const client = {
+      selectFrom: vi.fn(),
+      executeQuery,
+    };
+
+    const provider = createPostgresProvider({
+      client,
+      clientType: "kysely",
+    });
+
+    const event: AuthEvent = {
+      id: "4b5944af-7e28-4e8e-9f77-60fc43798679",
+      type: "user.logged_in",
+      timestamp: new Date("2026-01-01T00:00:00.000Z"),
+      status: "success",
+      userId: "user-1",
+      sessionId: "session-1",
+      organizationId: "org-1",
+      metadata: { provider: "github" },
+      ipAddress: "127.0.0.1",
+      userAgent: "vitest",
+      source: "app",
+      display: {
+        message: "Signed in",
+        severity: "info",
+      },
+    };
+
+    await provider.ingest(event);
+
+    const insertCall = executeQuery.mock.calls.find(([compiledQuery]) =>
+      compiledQuery.sql.includes("INSERT INTO public.auth_events"),
+    );
+
+    expect(insertCall).toBeDefined();
+    expect(insertCall?.[0].parameters).toEqual([
+      event.id,
+      event.type,
+      event.timestamp,
+      event.status,
+      event.userId,
+      event.sessionId,
+      event.organizationId,
+      JSON.stringify(event.metadata),
+      event.ipAddress,
+      event.userAgent,
+      event.source,
+      event.display?.message,
+      event.display?.severity,
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- Add Kysely to database detection and CLI database display fallback.
- Allow Studio event ingestion to accept Kysely Postgres clients through `clientType: "kysely"` using Kysely executeQuery.
- Update README/docs examples for Better Auth direct Kysely database config and regenerate `dist/`.

Closes #106.

## Validation
- `pnpm type-check`
- `pnpm test --run`
- `pnpm lint`
- `pnpm build`
- `pnpm --dir docs build` currently fails on an existing `docs/src/components/ui/globe.tsx` TypeScript excessive stack depth issue, after the docs production compile step succeeds.