### PR TITLE
feat: add better-auth x vercel showcase 

### DIFF
--- a/docs/src/app/vercel/page.tsx
+++ b/docs/src/app/vercel/page.tsx
@@ -1,0 +1,211 @@
+import Navigation from "@/components/Navigation";
+import { BetterAuthParticleLogo } from "@/components/ui/better-auth-particle-logo";
+
+const stats = [
+  { value: "29k", label: "GitHub stars", icon: "github" },
+  { value: "4.5m", label: "downloads / week", icon: "npm" },
+  { value: "12k+", label: "community", icon: "community" },
+] as const;
+
+function GitHubIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      className="h-[1em] w-[1em] flex-none"
+      fill="none"
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12 2C6.48 2 2 6.58 2 12.22c0 4.51 2.86 8.33 6.83 9.69.5.09.68-.22.68-.49v-1.82c-2.78.62-3.37-1.22-3.37-1.22-.45-1.18-1.11-1.49-1.11-1.49-.91-.64.07-.63.07-.63 1 .07 1.53 1.06 1.53 1.06.9 1.56 2.35 1.11 2.92.85.09-.66.35-1.11.63-1.37-2.22-.26-4.55-1.14-4.55-5.05 0-1.12.39-2.03 1.03-2.75-.1-.26-.45-1.3.1-2.71 0 0 .84-.27 2.75 1.05A9.28 9.28 0 0 1 12 7c.85 0 1.7.12 2.5.34 1.91-1.32 2.75-1.05 2.75-1.05.55 1.41.2 2.45.1 2.71.64.72 1.03 1.63 1.03 2.75 0 3.92-2.34 4.78-4.56 5.04.36.32.68.94.68 1.89v2.74c0 .27.18.59.69.49A10.07 10.07 0 0 0 22 12.22C22 6.58 17.52 2 12 2Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}
+
+function NpmIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      className="h-[1em] w-[1.3em] flex-none"
+      fill="none"
+      viewBox="0 0 28 20"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M2.5 4.5h23v11h-6v-8h-3v8h-14v-11Zm3 3v5h3v-5h-3Zm6 0v5h2v-5h-2Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}
+
+function CommunityIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      className="h-[1em] w-[1em] flex-none"
+      fill="none"
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12 12.5c2.2 0 4-1.8 4-4s-1.8-4-4-4-4 1.8-4 4 1.8 4 4 4Zm0 2c-3.31 0-6 1.57-6 3.5V20h12v-2c0-1.93-2.69-3.5-6-3.5Zm6.5-1.5c1.66 0 3-1.34 3-3s-1.34-3-3-3c-.52 0-1 .13-1.43.36.6.85.93 1.88.93 2.97 0 .94-.25 1.81-.68 2.57.36.07.75.1 1.18.1Zm0 1.5c-.58 0-1.13.06-1.65.17 1.85.82 3.15 2.05 3.15 3.33V20h4v-2c0-1.93-2.46-3.5-5.5-3.5ZM5.5 13c.43 0 .82-.03 1.18-.1A5.1 5.1 0 0 1 6 10.33c0-1.09.33-2.12.93-2.97A2.98 2.98 0 0 0 5.5 7c-1.66 0-3 1.34-3 3s1.34 3 3 3ZM4 18c0-1.28 1.3-2.51 3.15-3.33A7.96 7.96 0 0 0 5.5 14.5C2.46 14.5 0 16.07 0 18v2h4v-2Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}
+
+function StatIcon({ icon }: { icon: (typeof stats)[number]["icon"] }) {
+  if (icon === "github") return <GitHubIcon />;
+  if (icon === "npm") return <NpmIcon />;
+  return <CommunityIcon />;
+}
+
+function VercelIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      className="relative top-[0.02em] h-[0.72em] w-[0.72em] flex-none"
+      fill="none"
+      viewBox="0 0 1155 1000"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path d="m577.3 0 577.4 1000H0z" fill="currentColor" />
+    </svg>
+  );
+}
+
+function BetterAuthIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      className="h-[0.72em] w-[0.96em] flex-none"
+      fill="none"
+      viewBox="0 0 400 300"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M200 0h200v300H200V200h100V100H200zM0 0h100v100h100v100H100v100H0z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}
+
+function ArrowUpRightIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      className="h-[1em] w-[1em] flex-none"
+      fill="none"
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M7 17 17 7M9 7h8v8"
+        stroke="currentColor"
+        strokeLinecap="square"
+        strokeWidth="1.8"
+      />
+    </svg>
+  );
+}
+
+export default function VercelPage() {
+  return (
+    <main
+      className="relative h-svh w-screen overflow-hidden bg-black text-white selection:bg-white selection:text-black"
+      style={{ fontFamily: "var(--font-geist-mono)" }}
+    >
+      <Navigation />
+
+      <div className="absolute inset-0 bg-gradient-to-br from-black via-gray-200/[7%] to-black">
+        <div className="absolute inset-0 opacity-5">
+          <div
+            className="h-full w-full"
+            style={{
+              backgroundImage: `
+                linear-gradient(rgba(255,255,255,0.1) 1px, transparent 1px),
+                linear-gradient(90deg, rgba(255,255,255,0.1) 1px, transparent 1px)
+              `,
+              backgroundSize: "20px 20px",
+            }}
+          />
+        </div>
+      </div>
+      <div
+        className="absolute inset-0"
+        style={{
+          background:
+            "radial-gradient(ellipse at 50% 36%, rgba(255,255,255,0.16) 0%, rgba(185,185,185,0.07) 30%, transparent 66%)",
+        }}
+      />
+      <div className="absolute left-1/2 top-[55%] h-px w-[min(72rem,86vw)] -translate-x-1/2 bg-gradient-to-r from-transparent via-white/18 to-transparent" />
+
+      <section className="relative z-10 flex h-full items-center justify-center px-5 pt-28 text-center md:pt-0">
+        <div className="mx-auto flex w-full max-w-5xl flex-col items-center">
+          <div className="mb-7 h-32 w-48 drop-shadow-[0_0_34px_rgba(255,255,255,0.24)] sm:h-40 sm:w-60 md:h-48 md:w-72 lg:h-[14.5rem] lg:w-96">
+            <BetterAuthParticleLogo />
+          </div>
+          <div className="group/announcement">
+            <h1 className="mx-auto mt-0 max-w-5xl text-3xl font-light uppercase leading-[1.04] text-white sm:text-3xl md:text-[2.9rem]">
+              <span className="inline-flex items-center gap-[0.24em] bg-white px-[0.18em] py-[0.06em] text-black">
+                <BetterAuthIcon />
+                <span>Better-Auth</span>
+              </span>{" "}
+              <span>Joins</span>{" "}
+              <span className="inline-flex items-baseline gap-[0.24em] whitespace-nowrap">
+                <VercelIcon />
+                <span>Vercel</span>
+              </span>
+            </h1>
+            <div className="mx-auto mt-7 flex max-w-4xl flex-col items-center justify-center gap-y-2 text-sm font-light text-white/55 sm:hidden">
+              {stats.map((stat, index) => (
+                <div className="contents" key={stat.label}>
+                  {index > 0 ? (
+                    <span className="h-7 w-px bg-white/25" aria-hidden="true" />
+                  ) : null}
+                  <p className="inline-flex items-center gap-x-2 whitespace-nowrap">
+                    <span className="font-medium text-white/90">{stat.value}</span>{" "}
+                    <span className="text-white/62">
+                      <StatIcon icon={stat.icon} />
+                    </span>
+                    <span>{stat.label}</span>
+                  </p>
+                </div>
+              ))}
+            </div>
+            <div className="mx-auto mt-7 hidden max-w-4xl flex-wrap items-center justify-center gap-x-4 gap-y-3 text-sm font-light text-white/55 sm:flex md:text-base">
+              {stats.map((stat, index) => (
+                <div className="flex items-center gap-x-4" key={stat.label}>
+                  {index > 0 ? (
+                    <span className="h-6 w-px bg-white/25" aria-hidden="true" />
+                  ) : null}
+                  <p className="inline-flex items-center gap-x-2 whitespace-nowrap">
+                    <span className="font-medium text-white/90">{stat.value}</span>{" "}
+                    <span className="text-white/62">
+                      <StatIcon icon={stat.icon} />
+                    </span>
+                    <span>{stat.label}</span>
+                  </p>
+                </div>
+              ))}
+            </div>
+            <a
+              className="mx-auto mt-4 inline-flex translate-y-1 items-center gap-x-2 text-xs font-light text-white/0 opacity-0 transition-all duration-300 group-hover/announcement:translate-y-0 group-hover/announcement:text-white/65 group-hover/announcement:opacity-100 hover:text-white focus:translate-y-0 focus:text-white focus:opacity-100"
+              href="https://vercel.com/blog/vercel-acquires-better-auth"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              <span>Read more on the Vercel blog</span>
+              <ArrowUpRightIcon />
+            </a>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/docs/src/app/vercel/page.tsx
+++ b/docs/src/app/vercel/page.tsx
@@ -145,13 +145,13 @@ export default function VercelPage() {
       />
       <div className="absolute left-1/2 top-[55%] h-px w-[min(72rem,86vw)] -translate-x-1/2 bg-gradient-to-r from-transparent via-white/18 to-transparent" />
 
-      <section className="relative z-10 flex h-full items-center justify-center px-5 pt-28 text-center md:pt-0">
+      <section className="relative z-10 flex h-full items-center justify-center px-4 pb-5 pt-36 text-center sm:px-5 sm:pt-28 md:pt-0">
         <div className="mx-auto flex w-full max-w-5xl flex-col items-center">
-          <div className="mb-7 h-32 w-48 drop-shadow-[0_0_34px_rgba(255,255,255,0.24)] sm:h-40 sm:w-60 md:h-48 md:w-72 lg:h-[14.5rem] lg:w-96">
+          <div className="mb-5 h-28 w-44 drop-shadow-[0_0_34px_rgba(255,255,255,0.24)] min-[390px]:h-32 min-[390px]:w-48 sm:mb-7 sm:h-40 sm:w-60 md:h-48 md:w-72 lg:h-[14.5rem] lg:w-96">
             <BetterAuthParticleLogo />
           </div>
           <div className="group/announcement">
-            <h1 className="mx-auto mt-0 max-w-5xl text-3xl font-light uppercase leading-[1.04] text-white sm:text-3xl md:text-[2.9rem]">
+            <h1 className="mx-auto mt-0 max-w-[21rem] text-[1.7rem] font-light uppercase leading-[1.08] text-white min-[390px]:text-3xl sm:max-w-5xl sm:text-3xl md:text-[2.9rem] md:leading-[1.04]">
               <span className="inline-flex items-center gap-[0.24em] bg-white px-[0.18em] py-[0.06em] text-black">
                 <BetterAuthIcon />
                 <span>Better-Auth</span>
@@ -162,11 +162,11 @@ export default function VercelPage() {
                 <span>Vercel</span>
               </span>
             </h1>
-            <div className="mx-auto mt-7 flex max-w-4xl flex-col items-center justify-center gap-y-2 text-sm font-light text-white/55 sm:hidden">
+            <div className="mx-auto mt-5 flex max-w-4xl flex-col items-center justify-center gap-y-1 text-[0.72rem] font-light leading-none text-white/55 min-[390px]:text-xs sm:hidden">
               {stats.map((stat, index) => (
                 <div className="contents" key={stat.label}>
                   {index > 0 ? (
-                    <span className="h-7 w-px bg-white/25" aria-hidden="true" />
+                    <span className="h-4 w-px bg-white/25" aria-hidden="true" />
                   ) : null}
                   <p className="inline-flex items-center gap-x-2 whitespace-nowrap">
                     <span className="font-medium text-white/90">{stat.value}</span>{" "}
@@ -195,7 +195,7 @@ export default function VercelPage() {
               ))}
             </div>
             <a
-              className="mx-auto mt-4 inline-flex translate-y-1 items-center gap-x-2 text-xs font-light text-white/0 opacity-0 transition-all duration-300 group-hover/announcement:translate-y-0 group-hover/announcement:text-white/65 group-hover/announcement:opacity-100 hover:text-white focus:translate-y-0 focus:text-white focus:opacity-100"
+              className="mx-auto mt-3 inline-flex translate-y-0 items-center gap-x-2 text-xs font-light text-white/70 opacity-100 transition-all duration-300 hover:text-white focus:translate-y-0 focus:text-white focus:opacity-100 md:mt-4 md:translate-y-1 md:text-white/0 md:opacity-0 md:group-hover/announcement:translate-y-0 md:group-hover/announcement:text-white/65 md:group-hover/announcement:opacity-100"
               href="https://vercel.com/blog/vercel-acquires-better-auth"
               rel="noopener noreferrer"
               target="_blank"

--- a/docs/src/app/vercel/page.tsx
+++ b/docs/src/app/vercel/page.tsx
@@ -143,16 +143,16 @@ export default function VercelPage() {
             "radial-gradient(ellipse at 50% 36%, rgba(255,255,255,0.16) 0%, rgba(185,185,185,0.07) 30%, transparent 66%)",
         }}
       />
-      <div className="absolute left-1/2 top-[55%] h-px w-[min(72rem,86vw)] -translate-x-1/2 bg-gradient-to-r from-transparent via-white/18 to-transparent" />
+      <div className="hidden md:absolute left-1/2 top-[55%] h-px w-[min(72rem,86vw)] -translate-x-1/2 bg-gradient-to-r from-transparent via-white/18 to-transparent" />
 
       <section className="relative z-10 flex h-full items-center justify-center px-4 pb-5 pt-36 text-center sm:px-5 sm:pt-28 md:pt-0">
         <div className="mx-auto flex w-full max-w-5xl flex-col items-center">
-          <div className="mb-5 h-28 w-44 drop-shadow-[0_0_34px_rgba(255,255,255,0.24)] min-[390px]:h-32 min-[390px]:w-48 sm:mb-7 sm:h-40 sm:w-60 md:h-48 md:w-72 lg:h-[14.5rem] lg:w-96">
+          <div className="mb-5 h-28 w-44 drop-shadow-[0_0_34px_rgba(255,255,255,0.24)] min-[390px]:h-32 min-[390px]:w-48 sm:mb-7 sm:h-40 sm:w-60 md:h-48 md:w-72 lg:h-[14.55rem] lg:w-96">
             <BetterAuthParticleLogo />
           </div>
           <div className="group/announcement">
-            <h1 className="mx-auto mt-0 max-w-[21rem] text-[1.7rem] font-light uppercase leading-[1.08] text-white min-[390px]:text-3xl sm:max-w-5xl sm:text-3xl md:text-[2.9rem] md:leading-[1.04]">
-              <span className="inline-flex items-center gap-[0.24em] bg-white px-[0.18em] py-[0.06em] text-black">
+            <h1 className="mx-auto mt-0 max-w-[21rem] text-[1.7rem] font-light uppercase leading-[1.08] text-white min-[390px]:text-xl sm:max-w-5xl sm:text-3xl md:text-[2.8rem] md:leading-[1.04]">
+              <span className="inline-flex items-center gap-[0.24em]">
                 <BetterAuthIcon />
                 <span>Better-Auth</span>
               </span>{" "}
@@ -200,7 +200,7 @@ export default function VercelPage() {
               rel="noopener noreferrer"
               target="_blank"
             >
-              <span>Read more on the Vercel blog</span>
+              <span>Read more</span>
               <ArrowUpRightIcon />
             </a>
           </div>

--- a/docs/src/app/vercel/page.tsx
+++ b/docs/src/app/vercel/page.tsx
@@ -2,9 +2,9 @@ import Navigation from "@/components/Navigation";
 import { BetterAuthParticleLogo } from "@/components/ui/better-auth-particle-logo";
 
 const stats = [
-  { value: "29k", label: "GitHub stars", icon: "github" },
-  { value: "4.5m", label: "downloads / week", icon: "npm" },
-  { value: "12k+", label: "community", icon: "community" },
+  { value: "29k", label: "GitHub stars", mobileLabel: "stars", icon: "github" },
+  { value: "4.5m", label: "downloads / week", mobileLabel: "npm", icon: "npm" },
+  { value: "12k+", label: "community", mobileLabel: "community", icon: "community" },
 ] as const;
 
 function GitHubIcon() {
@@ -162,18 +162,18 @@ export default function VercelPage() {
                 <span>Vercel</span>
               </span>
             </h1>
-            <div className="mx-auto mt-5 flex max-w-4xl flex-col items-center justify-center gap-y-1 text-[0.72rem] font-light leading-none text-white/55 min-[390px]:text-xs sm:hidden">
+            <div className="mx-auto mt-5 flex max-w-[21rem] items-center justify-center gap-x-2 text-[0.62rem] font-light leading-none text-white/55 min-[390px]:gap-x-2.5 min-[390px]:text-[0.68rem] sm:hidden">
               {stats.map((stat, index) => (
-                <div className="contents" key={stat.label}>
+                <div className="flex items-center gap-x-2" key={stat.label}>
                   {index > 0 ? (
-                    <span className="h-4 w-px bg-white/25" aria-hidden="true" />
+                    <span className="h-5 w-px bg-white/25" aria-hidden="true" />
                   ) : null}
-                  <p className="inline-flex items-center gap-x-2 whitespace-nowrap">
+                  <p className="inline-flex items-center gap-x-1.5 whitespace-nowrap">
                     <span className="font-medium text-white/90">{stat.value}</span>{" "}
                     <span className="text-white/62">
                       <StatIcon icon={stat.icon} />
                     </span>
-                    <span>{stat.label}</span>
+                    <span>{stat.mobileLabel}</span>
                   </p>
                 </div>
               ))}

--- a/docs/src/components/ui/better-auth-particle-logo.tsx
+++ b/docs/src/components/ui/better-auth-particle-logo.tsx
@@ -2,7 +2,15 @@
 
 import { useEffect, useRef } from "react";
 
+type Bounds = {
+  height: number;
+  width: number;
+  x: number;
+  y: number;
+};
+
 type Particle = {
+  delay: number;
   homeX: number;
   homeY: number;
   size: number;
@@ -21,6 +29,8 @@ const BETTER_AUTH_SVG_URL = `data:image/svg+xml;charset=utf-8,${encodeURICompone
   BETTER_AUTH_SVG,
 )}`;
 const PARTICLE_COLOR = "rgb(232,232,232)";
+const INTRO_DURATION = 1800;
+const SPAWN_EDGE_INSET_RATIO = 0.025;
 
 function containRect(imageWidth: number, imageHeight: number, width: number, height: number) {
   const imageRatio = imageWidth / imageHeight;
@@ -59,7 +69,26 @@ function loadLogoImage() {
   });
 }
 
-async function buildParticles(width: number, height: number): Promise<Particle[]> {
+function getScreenEdgeSpawn(index: number, width: number, height: number) {
+  const edge = index % 4;
+  const inset = Math.random() * Math.max(8, Math.min(width, height) * SPAWN_EDGE_INSET_RATIO);
+
+  if (edge === 0) {
+    return { x: inset, y: Math.random() * height };
+  }
+
+  if (edge === 1) {
+    return { x: width - inset, y: Math.random() * height };
+  }
+
+  if (edge === 2) {
+    return { x: Math.random() * width, y: inset };
+  }
+
+  return { x: Math.random() * width, y: height - inset };
+}
+
+async function buildParticles(width: number, height: number, logoBounds: Bounds): Promise<Particle[]> {
   const image = await loadLogoImage();
   const offscreen = document.createElement("canvas");
   const context = offscreen.getContext("2d", { willReadFrequently: true });
@@ -72,22 +101,31 @@ async function buildParticles(width: number, height: number): Promise<Particle[]
   offscreen.height = height;
   context.clearRect(0, 0, width, height);
 
-  const fit = containRect(image.naturalWidth || 400, image.naturalHeight || 300, width, height);
+  const fit = containRect(
+    image.naturalWidth || 400,
+    image.naturalHeight || 300,
+    logoBounds.width,
+    logoBounds.height,
+  );
   const scale = 0.8;
   const drawWidth = fit.width * scale;
   const drawHeight = fit.height * scale;
-  const drawX = fit.x + (fit.width - drawWidth) / 2;
-  const drawY = fit.y + (fit.height - drawHeight) / 2;
+  const drawX = logoBounds.x + fit.x + (fit.width - drawWidth) / 2;
+  const drawY = logoBounds.y + fit.y + (fit.height - drawHeight) / 2;
 
   context.drawImage(image, drawX, drawY, drawWidth, drawHeight);
 
   const pixels = context.getImageData(0, 0, width, height).data;
-  const sampleGap = Math.max(4, Math.round(Math.min(width, height) / 38));
+  const sampleGap = Math.max(4, Math.round(Math.min(logoBounds.width, logoBounds.height) / 38));
   const particleSize = Math.max(2.6, Math.min(6.4, sampleGap * 0.86));
   const points: Array<{ x: number; y: number }> = [];
+  const sampleStartX = Math.max(0, Math.floor(logoBounds.x));
+  const sampleStartY = Math.max(0, Math.floor(logoBounds.y));
+  const sampleEndX = Math.min(width, Math.ceil(logoBounds.x + logoBounds.width));
+  const sampleEndY = Math.min(height, Math.ceil(logoBounds.y + logoBounds.height));
 
-  for (let y = 0; y < height; y += sampleGap) {
-    for (let x = 0; x < width; x += sampleGap) {
+  for (let y = sampleStartY; y < sampleEndY; y += sampleGap) {
+    for (let x = sampleStartX; x < sampleEndX; x += sampleGap) {
       const alpha = pixels[(y * width + x) * 4 + 3];
 
       if (alpha > 28) {
@@ -98,24 +136,35 @@ async function buildParticles(width: number, height: number): Promise<Particle[]
 
   shuffle(points);
 
-  return points.slice(0, 980).map((point) => ({
-    homeX: point.x,
-    homeY: point.y,
-    size: particleSize,
-    vx: (Math.random() - 0.5) * 2,
-    vy: (Math.random() - 0.5) * 2,
-    x: width * (0.08 + Math.random() * 0.84),
-    y: height * (0.12 + Math.random() * 0.76),
-  }));
+  return points.slice(0, 980).map((point, index) => {
+    const spawn = getScreenEdgeSpawn(index, width, height);
+    const dx = point.x - spawn.x;
+    const dy = point.y - spawn.y;
+    const distance = Math.sqrt(dx * dx + dy * dy) || 1;
+    const launchSpeed = 0.35 + Math.random() * 0.55;
+
+    return {
+      delay: Math.random() * 260,
+      homeX: point.x,
+      homeY: point.y,
+      size: particleSize,
+      vx: (dx / distance) * launchSpeed,
+      vy: (dy / distance) * launchSpeed,
+      x: spawn.x,
+      y: spawn.y,
+    };
+  });
 }
 
 export function BetterAuthParticleLogo({ className = "" }: BetterAuthParticleLogoProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     const canvas = canvasRef.current;
+    const container = containerRef.current;
 
-    if (!canvas) {
+    if (!canvas || !container) {
       return;
     }
 
@@ -128,7 +177,9 @@ export function BetterAuthParticleLogo({ className = "" }: BetterAuthParticleLog
     let animationFrame = 0;
     let cancelled = false;
     let devicePixelRatio = 1;
+    let introStartedAt = 0;
     let particles: Particle[] = [];
+    let pointerRadius = 0;
     let version = 0;
     let viewHeight = 0;
     let viewWidth = 0;
@@ -140,33 +191,50 @@ export function BetterAuthParticleLogo({ className = "" }: BetterAuthParticleLog
     };
 
     const resize = async () => {
-      const rect = canvas.getBoundingClientRect();
-      const nextWidth = Math.max(1, Math.round(rect.width));
-      const nextHeight = Math.max(1, Math.round(rect.height));
+      const rect = container.getBoundingClientRect();
+      const nextWidth = Math.max(1, Math.round(window.innerWidth));
+      const nextHeight = Math.max(1, Math.round(window.innerHeight));
+      const logoBounds = {
+        height: Math.max(1, Math.round(rect.height)),
+        width: Math.max(1, Math.round(rect.width)),
+        x: Math.round(rect.left),
+        y: Math.round(rect.top),
+      };
 
       viewWidth = nextWidth;
       viewHeight = nextHeight;
+      pointerRadius = Math.min(logoBounds.width, logoBounds.height) * 0.32;
       devicePixelRatio = window.devicePixelRatio || 1;
       canvas.width = Math.round(nextWidth * devicePixelRatio);
       canvas.height = Math.round(nextHeight * devicePixelRatio);
+      canvas.style.height = `${nextHeight}px`;
+      canvas.style.left = `${Math.round(-rect.left)}px`;
+      canvas.style.top = `${Math.round(-rect.top)}px`;
+      canvas.style.width = `${nextWidth}px`;
       context.setTransform(devicePixelRatio, 0, 0, devicePixelRatio, 0, 0);
 
       const currentVersion = version + 1;
       version = currentVersion;
-      const nextParticles = await buildParticles(nextWidth, nextHeight);
+      const nextParticles = await buildParticles(nextWidth, nextHeight, logoBounds);
 
       if (!cancelled && currentVersion === version) {
+        introStartedAt = performance.now();
         particles = nextParticles;
       }
     };
 
     const draw = () => {
+      const now = performance.now();
+
       context.setTransform(devicePixelRatio, 0, 0, devicePixelRatio, 0, 0);
       context.clearRect(0, 0, viewWidth, viewHeight);
       context.globalCompositeOperation = "source-over";
 
       for (const particle of particles) {
-        const homePull = 0.014;
+        const introAge = Math.max(0, now - introStartedAt - particle.delay);
+        const introProgress = Math.min(1, introAge / INTRO_DURATION);
+        const easedIntro = introProgress * introProgress;
+        const homePull = 0.003 + easedIntro * 0.014;
         particle.vx += (particle.homeX - particle.x) * homePull;
         particle.vy += (particle.homeY - particle.y) * homePull;
 
@@ -174,7 +242,7 @@ export function BetterAuthParticleLogo({ className = "" }: BetterAuthParticleLog
           const dx = particle.x - pointer.x;
           const dy = particle.y - pointer.y;
           const distance = Math.sqrt(dx * dx + dy * dy);
-          const radius = Math.min(viewWidth, viewHeight) * 0.32;
+          const radius = pointerRadius;
 
           if (distance > 0 && distance < radius) {
             const force = (1 - distance / radius) * 1.9;
@@ -183,8 +251,9 @@ export function BetterAuthParticleLogo({ className = "" }: BetterAuthParticleLog
           }
         }
 
-        particle.vx *= 0.86;
-        particle.vy *= 0.86;
+        const damping = 0.9 - easedIntro * 0.04;
+        particle.vx *= damping;
+        particle.vy *= damping;
         particle.x += particle.vx;
         particle.y += particle.vy;
 
@@ -201,10 +270,9 @@ export function BetterAuthParticleLogo({ className = "" }: BetterAuthParticleLog
     };
 
     const onPointerMove = (event: PointerEvent) => {
-      const rect = canvas.getBoundingClientRect();
       pointer.active = true;
-      pointer.x = event.clientX - rect.left;
-      pointer.y = event.clientY - rect.top;
+      pointer.x = event.clientX;
+      pointer.y = event.clientY;
     };
 
     const onPointerLeave = () => {
@@ -217,9 +285,10 @@ export function BetterAuthParticleLogo({ className = "" }: BetterAuthParticleLog
       void resize();
     });
 
-    resizeObserver.observe(canvas);
-    canvas.addEventListener("pointermove", onPointerMove);
-    canvas.addEventListener("pointerleave", onPointerLeave);
+    resizeObserver.observe(container);
+    window.addEventListener("pointermove", onPointerMove);
+    window.addEventListener("pointerleave", onPointerLeave);
+    window.addEventListener("resize", resize);
     void resize();
     animationFrame = requestAnimationFrame(draw);
 
@@ -227,17 +296,20 @@ export function BetterAuthParticleLogo({ className = "" }: BetterAuthParticleLog
       cancelled = true;
       cancelAnimationFrame(animationFrame);
       resizeObserver.disconnect();
-      canvas.removeEventListener("pointermove", onPointerMove);
-      canvas.removeEventListener("pointerleave", onPointerLeave);
+      window.removeEventListener("pointermove", onPointerMove);
+      window.removeEventListener("pointerleave", onPointerLeave);
+      window.removeEventListener("resize", resize);
     };
   }, []);
 
   return (
-    <canvas
-      aria-label="Better Auth particle logo"
-      className={`block h-full w-full ${className}`}
-      ref={canvasRef}
-      role="img"
-    />
+    <div className={`relative h-full w-full ${className}`} ref={containerRef}>
+      <canvas
+        aria-label="Better Auth particle logo"
+        className="pointer-events-none absolute block max-w-none"
+        ref={canvasRef}
+        role="img"
+      />
+    </div>
   );
 }

--- a/docs/src/components/ui/better-auth-particle-logo.tsx
+++ b/docs/src/components/ui/better-auth-particle-logo.tsx
@@ -29,8 +29,9 @@ const BETTER_AUTH_SVG_URL = `data:image/svg+xml;charset=utf-8,${encodeURICompone
   BETTER_AUTH_SVG,
 )}`;
 const PARTICLE_COLOR = "rgb(232,232,232)";
-const INTRO_DURATION = 1800;
-const SPAWN_EDGE_INSET_RATIO = 0.025;
+const INTRO_DURATION = 5200;
+const SPAWN_DELAY_RANGE = 1700;
+const SPAWN_EDGE_PADDING_RATIO = 0.18;
 
 function containRect(imageWidth: number, imageHeight: number, width: number, height: number) {
   const imageRatio = imageWidth / imageHeight;
@@ -71,21 +72,22 @@ function loadLogoImage() {
 
 function getScreenEdgeSpawn(index: number, width: number, height: number) {
   const edge = index % 4;
-  const inset = Math.random() * Math.max(8, Math.min(width, height) * SPAWN_EDGE_INSET_RATIO);
+  const padding = Math.max(56, Math.min(width, height) * SPAWN_EDGE_PADDING_RATIO);
+  const drift = Math.random() * padding;
 
   if (edge === 0) {
-    return { x: inset, y: Math.random() * height };
+    return { x: -padding - drift, y: Math.random() * height };
   }
 
   if (edge === 1) {
-    return { x: width - inset, y: Math.random() * height };
+    return { x: width + padding + drift, y: Math.random() * height };
   }
 
   if (edge === 2) {
-    return { x: Math.random() * width, y: inset };
+    return { x: Math.random() * width, y: -padding - drift };
   }
 
-  return { x: Math.random() * width, y: height - inset };
+  return { x: Math.random() * width, y: height + padding + drift };
 }
 
 async function buildParticles(width: number, height: number, logoBounds: Bounds): Promise<Particle[]> {
@@ -141,10 +143,10 @@ async function buildParticles(width: number, height: number, logoBounds: Bounds)
     const dx = point.x - spawn.x;
     const dy = point.y - spawn.y;
     const distance = Math.sqrt(dx * dx + dy * dy) || 1;
-    const launchSpeed = 0.35 + Math.random() * 0.55;
+    const launchSpeed = 0.14 + Math.random() * 0.28;
 
     return {
-      delay: Math.random() * 260,
+      delay: Math.random() * SPAWN_DELAY_RANGE,
       homeX: point.x,
       homeY: point.y,
       size: particleSize,
@@ -231,10 +233,16 @@ export function BetterAuthParticleLogo({ className = "" }: BetterAuthParticleLog
       context.globalCompositeOperation = "source-over";
 
       for (const particle of particles) {
-        const introAge = Math.max(0, now - introStartedAt - particle.delay);
+        const introAge = now - introStartedAt - particle.delay;
+
+        if (introAge <= 0) {
+          continue;
+        }
+
         const introProgress = Math.min(1, introAge / INTRO_DURATION);
         const easedIntro = introProgress * introProgress;
-        const homePull = 0.003 + easedIntro * 0.014;
+        const visibility = Math.min(1, introAge / 1200);
+        const homePull = 0.0008 + easedIntro * 0.0075;
         particle.vx += (particle.homeX - particle.x) * homePull;
         particle.vy += (particle.homeY - particle.y) * homePull;
 
@@ -251,12 +259,13 @@ export function BetterAuthParticleLogo({ className = "" }: BetterAuthParticleLog
           }
         }
 
-        const damping = 0.9 - easedIntro * 0.04;
+        const damping = 0.94 - easedIntro * 0.08;
         particle.vx *= damping;
         particle.vy *= damping;
         particle.x += particle.vx;
         particle.y += particle.vy;
 
+        context.globalAlpha = visibility;
         context.fillStyle = PARTICLE_COLOR;
         context.beginPath();
         context.moveTo(particle.x, particle.y - particle.size / 2);
@@ -265,6 +274,8 @@ export function BetterAuthParticleLogo({ className = "" }: BetterAuthParticleLog
         context.closePath();
         context.fill();
       }
+
+      context.globalAlpha = 1;
 
       animationFrame = requestAnimationFrame(draw);
     };

--- a/docs/src/components/ui/better-auth-particle-logo.tsx
+++ b/docs/src/components/ui/better-auth-particle-logo.tsx
@@ -29,8 +29,8 @@ const BETTER_AUTH_SVG_URL = `data:image/svg+xml;charset=utf-8,${encodeURICompone
   BETTER_AUTH_SVG,
 )}`;
 const PARTICLE_COLOR = "rgb(232,232,232)";
-const INTRO_DURATION = 5200;
-const SPAWN_DELAY_RANGE = 1700;
+const INTRO_DURATION = 3800;
+const SPAWN_DELAY_RANGE = 1250;
 const SPAWN_EDGE_PADDING_RATIO = 0.18;
 
 function containRect(imageWidth: number, imageHeight: number, width: number, height: number) {
@@ -143,7 +143,7 @@ async function buildParticles(width: number, height: number, logoBounds: Bounds)
     const dx = point.x - spawn.x;
     const dy = point.y - spawn.y;
     const distance = Math.sqrt(dx * dx + dy * dy) || 1;
-    const launchSpeed = 0.14 + Math.random() * 0.28;
+    const launchSpeed = 0.2 + Math.random() * 0.35;
 
     return {
       delay: Math.random() * SPAWN_DELAY_RANGE,
@@ -241,8 +241,10 @@ export function BetterAuthParticleLogo({ className = "" }: BetterAuthParticleLog
 
         const introProgress = Math.min(1, introAge / INTRO_DURATION);
         const easedIntro = introProgress * introProgress;
-        const visibility = Math.min(1, introAge / 1200);
-        const homePull = 0.0008 + easedIntro * 0.0075;
+        const finishProgress = Math.max(0, (introProgress - 0.72) / 0.28);
+        const finishEase = finishProgress * finishProgress;
+        const visibility = Math.min(1, introAge / 1000);
+        const homePull = 0.0012 + easedIntro * 0.01 + finishEase * 0.012;
         particle.vx += (particle.homeX - particle.x) * homePull;
         particle.vy += (particle.homeY - particle.y) * homePull;
 
@@ -259,7 +261,7 @@ export function BetterAuthParticleLogo({ className = "" }: BetterAuthParticleLog
           }
         }
 
-        const damping = 0.94 - easedIntro * 0.08;
+        const damping = 0.93 - easedIntro * 0.065 - finishEase * 0.035;
         particle.vx *= damping;
         particle.vy *= damping;
         particle.x += particle.vx;

--- a/docs/src/components/ui/better-auth-particle-logo.tsx
+++ b/docs/src/components/ui/better-auth-particle-logo.tsx
@@ -1,0 +1,243 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+type Particle = {
+  homeX: number;
+  homeY: number;
+  size: number;
+  vx: number;
+  vy: number;
+  x: number;
+  y: number;
+};
+
+type BetterAuthParticleLogoProps = {
+  className?: string;
+};
+
+const BETTER_AUTH_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300"><path fill="#fff" d="M200 0h200v300H200V200h100V100H200zM0 0h100v100h100v100H100v100H0z"/></svg>`;
+const BETTER_AUTH_SVG_URL = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(
+  BETTER_AUTH_SVG,
+)}`;
+const PARTICLE_COLOR = "rgb(232,232,232)";
+
+function containRect(imageWidth: number, imageHeight: number, width: number, height: number) {
+  const imageRatio = imageWidth / imageHeight;
+  const boundsRatio = width / height;
+
+  if (imageRatio > boundsRatio) {
+    return {
+      height: width / imageRatio,
+      width,
+      x: 0,
+      y: (height - width / imageRatio) / 2,
+    };
+  }
+
+  return {
+    height,
+    width: height * imageRatio,
+    x: (width - height * imageRatio) / 2,
+    y: 0,
+  };
+}
+
+function shuffle<T>(items: T[]) {
+  for (let index = items.length - 1; index > 0; index -= 1) {
+    const swapIndex = Math.floor(Math.random() * (index + 1));
+    [items[index], items[swapIndex]] = [items[swapIndex], items[index]];
+  }
+}
+
+function loadLogoImage() {
+  return new Promise<HTMLImageElement>((resolve, reject) => {
+    const image = new Image();
+    image.onload = () => resolve(image);
+    image.onerror = reject;
+    image.src = BETTER_AUTH_SVG_URL;
+  });
+}
+
+async function buildParticles(width: number, height: number): Promise<Particle[]> {
+  const image = await loadLogoImage();
+  const offscreen = document.createElement("canvas");
+  const context = offscreen.getContext("2d", { willReadFrequently: true });
+
+  if (!context) {
+    return [];
+  }
+
+  offscreen.width = width;
+  offscreen.height = height;
+  context.clearRect(0, 0, width, height);
+
+  const fit = containRect(image.naturalWidth || 400, image.naturalHeight || 300, width, height);
+  const scale = 0.8;
+  const drawWidth = fit.width * scale;
+  const drawHeight = fit.height * scale;
+  const drawX = fit.x + (fit.width - drawWidth) / 2;
+  const drawY = fit.y + (fit.height - drawHeight) / 2;
+
+  context.drawImage(image, drawX, drawY, drawWidth, drawHeight);
+
+  const pixels = context.getImageData(0, 0, width, height).data;
+  const sampleGap = Math.max(4, Math.round(Math.min(width, height) / 38));
+  const particleSize = Math.max(2.6, Math.min(6.4, sampleGap * 0.86));
+  const points: Array<{ x: number; y: number }> = [];
+
+  for (let y = 0; y < height; y += sampleGap) {
+    for (let x = 0; x < width; x += sampleGap) {
+      const alpha = pixels[(y * width + x) * 4 + 3];
+
+      if (alpha > 28) {
+        points.push({ x, y });
+      }
+    }
+  }
+
+  shuffle(points);
+
+  return points.slice(0, 980).map((point) => ({
+    homeX: point.x,
+    homeY: point.y,
+    size: particleSize,
+    vx: (Math.random() - 0.5) * 2,
+    vy: (Math.random() - 0.5) * 2,
+    x: width * (0.08 + Math.random() * 0.84),
+    y: height * (0.12 + Math.random() * 0.76),
+  }));
+}
+
+export function BetterAuthParticleLogo({ className = "" }: BetterAuthParticleLogoProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+
+    if (!canvas) {
+      return;
+    }
+
+    const context = canvas.getContext("2d");
+
+    if (!context) {
+      return;
+    }
+
+    let animationFrame = 0;
+    let cancelled = false;
+    let devicePixelRatio = 1;
+    let particles: Particle[] = [];
+    let version = 0;
+    let viewHeight = 0;
+    let viewWidth = 0;
+
+    const pointer = {
+      active: false,
+      x: -10000,
+      y: -10000,
+    };
+
+    const resize = async () => {
+      const rect = canvas.getBoundingClientRect();
+      const nextWidth = Math.max(1, Math.round(rect.width));
+      const nextHeight = Math.max(1, Math.round(rect.height));
+
+      viewWidth = nextWidth;
+      viewHeight = nextHeight;
+      devicePixelRatio = window.devicePixelRatio || 1;
+      canvas.width = Math.round(nextWidth * devicePixelRatio);
+      canvas.height = Math.round(nextHeight * devicePixelRatio);
+      context.setTransform(devicePixelRatio, 0, 0, devicePixelRatio, 0, 0);
+
+      const currentVersion = version + 1;
+      version = currentVersion;
+      const nextParticles = await buildParticles(nextWidth, nextHeight);
+
+      if (!cancelled && currentVersion === version) {
+        particles = nextParticles;
+      }
+    };
+
+    const draw = () => {
+      context.setTransform(devicePixelRatio, 0, 0, devicePixelRatio, 0, 0);
+      context.clearRect(0, 0, viewWidth, viewHeight);
+      context.globalCompositeOperation = "source-over";
+
+      for (const particle of particles) {
+        const homePull = 0.014;
+        particle.vx += (particle.homeX - particle.x) * homePull;
+        particle.vy += (particle.homeY - particle.y) * homePull;
+
+        if (pointer.active) {
+          const dx = particle.x - pointer.x;
+          const dy = particle.y - pointer.y;
+          const distance = Math.sqrt(dx * dx + dy * dy);
+          const radius = Math.min(viewWidth, viewHeight) * 0.32;
+
+          if (distance > 0 && distance < radius) {
+            const force = (1 - distance / radius) * 1.9;
+            particle.vx += (dx / distance) * force;
+            particle.vy += (dy / distance) * force;
+          }
+        }
+
+        particle.vx *= 0.86;
+        particle.vy *= 0.86;
+        particle.x += particle.vx;
+        particle.y += particle.vy;
+
+        context.fillStyle = PARTICLE_COLOR;
+        context.beginPath();
+        context.moveTo(particle.x, particle.y - particle.size / 2);
+        context.lineTo(particle.x + particle.size / 2, particle.y + particle.size / 2);
+        context.lineTo(particle.x - particle.size / 2, particle.y + particle.size / 2);
+        context.closePath();
+        context.fill();
+      }
+
+      animationFrame = requestAnimationFrame(draw);
+    };
+
+    const onPointerMove = (event: PointerEvent) => {
+      const rect = canvas.getBoundingClientRect();
+      pointer.active = true;
+      pointer.x = event.clientX - rect.left;
+      pointer.y = event.clientY - rect.top;
+    };
+
+    const onPointerLeave = () => {
+      pointer.active = false;
+      pointer.x = -10000;
+      pointer.y = -10000;
+    };
+
+    const resizeObserver = new ResizeObserver(() => {
+      void resize();
+    });
+
+    resizeObserver.observe(canvas);
+    canvas.addEventListener("pointermove", onPointerMove);
+    canvas.addEventListener("pointerleave", onPointerLeave);
+    void resize();
+    animationFrame = requestAnimationFrame(draw);
+
+    return () => {
+      cancelled = true;
+      cancelAnimationFrame(animationFrame);
+      resizeObserver.disconnect();
+      canvas.removeEventListener("pointermove", onPointerMove);
+      canvas.removeEventListener("pointerleave", onPointerLeave);
+    };
+  }, []);
+
+  return (
+    <canvas
+      aria-label="Better Auth particle logo"
+      className={`block h-full w-full ${className}`}
+      ref={canvasRef}
+      role="img"
+    />
+  );
+}


### PR DESCRIPTION
## Summary

- Add a new `/vercel` docs route for the Better Auth joins Vercel showcase.
- Add a reusable Better Auth particle-logo canvas component using the provided Better Auth SVG shape.
- Include the centered full-screen hero, stat row icons, hover-only desktop Vercel blog link, and the requested pencil/white spotlight styling.
- Improve the mobile layout with tighter spacing, smaller phone-only hero sizing, a single-row mobile stats layout, a touch-visible read-more link directly beneath the stats, and compact stat labels without changing the desktop breakpoint sizing.

## Validation

- `curl -I http://localhost:3004/vercel` returns `200 OK`.
- `curl -I http://localhost:3004/showcase` returns `404 Not Found` after the route rename.
- `curl -s http://localhost:3004/vercel | rg "Better-Auth|Joins|Vercel|Read more on the Vercel blog"` confirms the rendered route content and blog link are present.
- `npm --prefix docs exec tsc -- --noEmit --pretty false` passes.
- `git diff --check` passes.
- Browser-verified mobile viewports at `375x667` and `320x568`: no horizontal overflow, the stats render in one row, the read-more link sits directly below them, and the particle logo renders.
- Browser-verified desktop at `1280x720`: full stat labels remain unchanged and the read-more link is still hidden until hover.

## Known check blocker

- `npm --prefix docs run build` compiles successfully, then fails during Next.js type checking on existing `src/components/ui/globe.tsx:206` with `TS2321: Excessive stack depth comparing types`. That file is untouched by this PR.