### PR TITLE
chore: seo configs

### DIFF
--- a/docs/next.config.ts
+++ b/docs/next.config.ts
@@ -1,7 +1,22 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  async redirects() {
+    return [
+      {
+        source: "/:path*",
+        has: [{ type: "host", value: "better-auth-studio.vercel.app" }],
+        destination: "https://www.better-auth.studio/:path*",
+        permanent: true,
+      },
+      {
+        source: "/:path*",
+        has: [{ type: "host", value: "better-auth.studio" }],
+        destination: "https://www.better-auth.studio/:path*",
+        permanent: true,
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/docs/src/app/changelog/layout.tsx
+++ b/docs/src/app/changelog/layout.tsx
@@ -1,0 +1,12 @@
+import type { ReactNode } from "react";
+import { createPageMetadata } from "@/lib/site";
+
+export const metadata = createPageMetadata({
+  title: "Changelog",
+  description: "Recent Better Auth Studio releases, fixes, and feature updates.",
+  path: "/changelog",
+});
+
+export default function ChangelogLayout({ children }: { children: ReactNode }) {
+  return children;
+}

--- a/docs/src/app/guides/layout.tsx
+++ b/docs/src/app/guides/layout.tsx
@@ -1,0 +1,12 @@
+import type { ReactNode } from "react";
+import { createPageMetadata } from "@/lib/site";
+
+export const metadata = createPageMetadata({
+  title: "Guides",
+  description: "Step-by-step guides for self-hosting and getting started with Better Auth Studio.",
+  path: "/guides",
+});
+
+export default function GuidesLayout({ children }: { children: ReactNode }) {
+  return children;
+}

--- a/docs/src/app/installation/layout.tsx
+++ b/docs/src/app/installation/layout.tsx
@@ -1,0 +1,12 @@
+import type { ReactNode } from "react";
+import { createPageMetadata } from "@/lib/site";
+
+export const metadata = createPageMetadata({
+  title: "Installation",
+  description: "Install Better Auth Studio and start it in your Better Auth project.",
+  path: "/installation",
+});
+
+export default function InstallationLayout({ children }: { children: ReactNode }) {
+  return children;
+}

--- a/docs/src/app/layout.tsx
+++ b/docs/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import { createPageMetadata } from "@/lib/site";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -13,29 +14,10 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "Better Auth Studio",
-  description:
-    "An admin dashboard for Better Auth. Manage users, sessions, organizations, and more with an intuitive interface.",
+  ...createPageMetadata(),
   icons: {
     icon: [{ url: "/favicon.svg", type: "image/svg+xml" }],
     shortcut: "/favicon.svg",
-  },
-  openGraph: {
-    title: "Better Auth Studio",
-    description:
-      "An admin dashboard for Better Auth. Manage users, sessions, organizations, and more with an intuitive interface.",
-    images: [
-      {
-        url: "/og.png",
-        width: 1200,
-        height: 630,
-        alt: "Better Auth Studio",
-      },
-    ],
-  },
-  twitter: {
-    card: "summary_large_image",
-    images: ["/og.png"],
   },
 };
 

--- a/docs/src/app/robots.ts
+++ b/docs/src/app/robots.ts
@@ -1,0 +1,13 @@
+import type { MetadataRoute } from "next";
+import { SITE_URL } from "@/lib/site";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+    },
+    sitemap: `${SITE_URL}/sitemap.xml`,
+    host: SITE_URL,
+  };
+}

--- a/docs/src/app/self-hosting/layout.tsx
+++ b/docs/src/app/self-hosting/layout.tsx
@@ -1,0 +1,12 @@
+import type { ReactNode } from "react";
+import { createPageMetadata } from "@/lib/site";
+
+export const metadata = createPageMetadata({
+  title: "Self-Hosting",
+  description: "Deploy Better Auth Studio inside your own application across supported frameworks.",
+  path: "/self-hosting",
+});
+
+export default function SelfHostingLayout({ children }: { children: ReactNode }) {
+  return children;
+}

--- a/docs/src/app/sitemap.ts
+++ b/docs/src/app/sitemap.ts
@@ -1,0 +1,25 @@
+import type { MetadataRoute } from "next";
+import { SITE_URL } from "@/lib/site";
+
+const routes = [
+  { path: "/", priority: 1 },
+  { path: "/installation", priority: 0.9 },
+  { path: "/guides", priority: 0.8 },
+  { path: "/self-hosting", priority: 0.8 },
+  { path: "/vercel", priority: 0.7 },
+  { path: "/changelog", priority: 0.7 },
+  { path: "/v/1.1.2", priority: 0.6 },
+  { path: "/v/1.1.1", priority: 0.5 },
+  { path: "/v/1.1.0", priority: 0.5 },
+] as const;
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const lastModified = new Date();
+
+  return routes.map(({ path, priority }) => ({
+    url: `${SITE_URL}${path}`,
+    lastModified,
+    changeFrequency: path === "/changelog" ? "weekly" : "monthly",
+    priority,
+  }));
+}

--- a/docs/src/app/v/1.1.0/layout.tsx
+++ b/docs/src/app/v/1.1.0/layout.tsx
@@ -1,0 +1,12 @@
+import type { ReactNode } from "react";
+import { createPageMetadata } from "@/lib/site";
+
+export const metadata = createPageMetadata({
+  title: "Version 1.1.0",
+  description: "Better Auth Studio v1.1.0 release notes and framework support updates.",
+  path: "/v/1.1.0",
+});
+
+export default function Version110Layout({ children }: { children: ReactNode }) {
+  return children;
+}

--- a/docs/src/app/v/1.1.1/layout.tsx
+++ b/docs/src/app/v/1.1.1/layout.tsx
@@ -1,0 +1,12 @@
+import type { ReactNode } from "react";
+import { createPageMetadata } from "@/lib/site";
+
+export const metadata = createPageMetadata({
+  title: "Version 1.1.1",
+  description: "Better Auth Studio v1.1.1 release notes and event ingestion updates.",
+  path: "/v/1.1.1",
+});
+
+export default function Version111Layout({ children }: { children: ReactNode }) {
+  return children;
+}

--- a/docs/src/app/v/1.1.2/layout.tsx
+++ b/docs/src/app/v/1.1.2/layout.tsx
@@ -1,0 +1,12 @@
+import type { ReactNode } from "react";
+import { createPageMetadata } from "@/lib/site";
+
+export const metadata = createPageMetadata({
+  title: "Version 1.1.2",
+  description: "Better Auth Studio v1.1.2 release notes and product updates.",
+  path: "/v/1.1.2",
+});
+
+export default function Version112Layout({ children }: { children: ReactNode }) {
+  return children;
+}

--- a/docs/src/app/vercel/layout.tsx
+++ b/docs/src/app/vercel/layout.tsx
@@ -1,0 +1,12 @@
+import type { ReactNode } from "react";
+import { createPageMetadata } from "@/lib/site";
+
+export const metadata = createPageMetadata({
+  title: "Vercel",
+  description: "Deploy and run Better Auth Studio with Vercel.",
+  path: "/vercel",
+});
+
+export default function VercelLayout({ children }: { children: ReactNode }) {
+  return children;
+}

--- a/docs/src/lib/site.ts
+++ b/docs/src/lib/site.ts
@@ -1,0 +1,50 @@
+import type { Metadata } from "next";
+
+export const SITE_NAME = "Better Auth Studio";
+export const SITE_DESCRIPTION =
+  "An admin dashboard for Better Auth. Manage users, sessions, organizations, and more with an intuitive interface.";
+export const SITE_URL = "https://www.better-auth.studio";
+
+type PageMetadataOptions = {
+  title?: string;
+  description?: string;
+  path?: string;
+};
+
+export function createPageMetadata({
+  title = SITE_NAME,
+  description = SITE_DESCRIPTION,
+  path = "/",
+}: PageMetadataOptions = {}): Metadata {
+  const fullTitle = title === SITE_NAME ? SITE_NAME : `${title} | ${SITE_NAME}`;
+  const url = path.startsWith("http") ? path : `${SITE_URL}${path}`;
+
+  return {
+    metadataBase: new URL(SITE_URL),
+    title: fullTitle,
+    description,
+    alternates: {
+      canonical: url,
+    },
+    openGraph: {
+      title: fullTitle,
+      description,
+      url,
+      siteName: SITE_NAME,
+      images: [
+        {
+          url: `${SITE_URL}/og.png`,
+          width: 1200,
+          height: 630,
+          alt: SITE_NAME,
+        },
+      ],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: fullTitle,
+      description,
+      images: [`${SITE_URL}/og.png`],
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- Add canonical metadata for the docs site using `https://www.better-auth.studio` as the preferred domain.
- Add generated `robots.txt` and `sitemap.xml` routes that point crawlers to the custom domain.
- Redirect the default Vercel domain and apex domain to `https://www.better-auth.studio` to reduce duplicate indexing.

## Why

Search results were showing `better-auth-studio.vercel.app` alongside the real `better-auth.studio` domain because the Vercel URL returned the same page with a `200 OK`. The redirect and canonical signals make the custom domain the preferred URL for crawlers.

## Validation

- `git status -sb` shows the branch is clean.
- `pnpm --dir docs build` compiles, then fails on an existing TypeScript depth issue in `docs/src/components/ui/globe.tsx:206`.
- `pnpm --dir docs lint` fails before linting due to the existing ESLint 9 / `@typescript-eslint` rule compatibility error.