### PR TITLE
fix: serve TanStack Studio assets in monorepos

### DIFF
--- a/dist/adapters/tanstack-start.js
+++ b/dist/adapters/tanstack-start.js
@@ -1,5 +1,7 @@
 import { handleStudioRequest } from "../core/handler.js";
 import { injectEventHooks, injectLastSeenAtHooks } from "../utils/hook-injector.js";
+const STATIC_ASSET_QUERY_PARAM = "__better_auth_studio_asset";
+const STATIC_ASSET_PATH_PATTERN = /^\/(?:assets\/[^/?#]+|vite\.svg|favicon\.svg|logo\.png)$/;
 /**
  * TanStack Start adapter for Better Auth Studio
  *
@@ -35,7 +37,7 @@ export function betterAuthStudio(config) {
         try {
             const universalReq = await convertTanStackStartToUniversal(request, config);
             const universalRes = await handleStudioRequest(universalReq, config);
-            return universalToResponse(universalRes);
+            return universalToResponse(universalRes, config);
         }
         catch (error) {
             console.error("Studio handler error:", error);
@@ -87,11 +89,15 @@ async function convertTanStackStartToUniversal(request, config) {
     const basePath = config.basePath || "/api/studio";
     const normalizedBasePath = basePath.endsWith("/") ? basePath.slice(0, -1) : basePath;
     const url = new URL(request.url);
-    let path = url.pathname;
-    if (path.startsWith(normalizedBasePath)) {
+    const queryAssetPath = url.searchParams.get(STATIC_ASSET_QUERY_PARAM);
+    const acceptedQueryAssetPath = queryAssetPath && STATIC_ASSET_PATH_PATTERN.test(queryAssetPath) ? queryAssetPath : null;
+    let path = acceptedQueryAssetPath || url.pathname;
+    if (!acceptedQueryAssetPath && path.startsWith(normalizedBasePath)) {
         path = path.slice(normalizedBasePath.length) || "/";
     }
-    const pathWithQuery = path + url.search;
+    url.searchParams.delete(STATIC_ASSET_QUERY_PARAM);
+    const query = url.searchParams.toString();
+    const pathWithQuery = path + (query ? `?${query}` : "");
     return {
         url: pathWithQuery,
         method: method,
@@ -99,13 +105,32 @@ async function convertTanStackStartToUniversal(request, config) {
         body,
     };
 }
-function universalToResponse(res) {
+function universalToResponse(res, config) {
     const headers = new Headers(res.headers);
     res.setCookies?.forEach((cookie) => {
         headers.append("Set-Cookie", cookie);
     });
-    return new Response(res.body, {
+    let body = res.body;
+    if (typeof body === "string" &&
+        headers.get("Content-Type")?.toLowerCase().includes("text/html")) {
+        body = rewriteStaticAssetUrls(body, config.basePath || "/api/studio");
+    }
+    return new Response(body, {
         status: res.status,
         headers,
+    });
+}
+/**
+ * Nitro can treat nested URLs ending in .js/.css as public files before a
+ * TanStack Start splat route gets a chance to handle them. Keep Studio assets
+ * on the exact server-route URL and carry the requested file in the query.
+ */
+function rewriteStaticAssetUrls(html, basePath) {
+    const normalizedBasePath = basePath.endsWith("/") ? basePath.slice(0, -1) : basePath;
+    const escapedBasePath = normalizedBasePath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const assetUrlPattern = new RegExp(`((?:href|src)=["'])${escapedBasePath}(/(?:assets/[^"'?#]+|vite\\.svg|favicon\\.svg|logo\\.png))(["'])`, "g");
+    return html.replace(assetUrlPattern, (_match, prefix, assetPath, suffix) => {
+        const query = new URLSearchParams({ [STATIC_ASSET_QUERY_PARAM]: assetPath });
+        return `${prefix}${normalizedBasePath}?${query.toString()}${suffix}`;
     });
 }

--- a/src/adapters/tanstack-start.ts
+++ b/src/adapters/tanstack-start.ts
@@ -7,6 +7,9 @@ type TanStackStartHandlerContext = {
   request: Request;
 };
 
+const STATIC_ASSET_QUERY_PARAM = "__better_auth_studio_asset";
+const STATIC_ASSET_PATH_PATTERN = /^\/(?:assets\/[^/?#]+|vite\.svg|favicon\.svg|logo\.png)$/;
+
 /**
  * TanStack Start adapter for Better Auth Studio
  *
@@ -42,7 +45,7 @@ export function betterAuthStudio(config: StudioConfig) {
     try {
       const universalReq = await convertTanStackStartToUniversal(request, config);
       const universalRes = await handleStudioRequest(universalReq, config);
-      return universalToResponse(universalRes);
+      return universalToResponse(universalRes, config);
     } catch (error) {
       console.error("Studio handler error:", error);
       return new Response(JSON.stringify({ error: "Internal server error" }), {
@@ -97,13 +100,18 @@ async function convertTanStackStartToUniversal(
   const normalizedBasePath = basePath.endsWith("/") ? basePath.slice(0, -1) : basePath;
 
   const url = new URL(request.url);
-  let path = url.pathname;
+  const queryAssetPath = url.searchParams.get(STATIC_ASSET_QUERY_PARAM);
+  const acceptedQueryAssetPath =
+    queryAssetPath && STATIC_ASSET_PATH_PATTERN.test(queryAssetPath) ? queryAssetPath : null;
+  let path = acceptedQueryAssetPath || url.pathname;
 
-  if (path.startsWith(normalizedBasePath)) {
+  if (!acceptedQueryAssetPath && path.startsWith(normalizedBasePath)) {
     path = path.slice(normalizedBasePath.length) || "/";
   }
 
-  const pathWithQuery = path + url.search;
+  url.searchParams.delete(STATIC_ASSET_QUERY_PARAM);
+  const query = url.searchParams.toString();
+  const pathWithQuery = path + (query ? `?${query}` : "");
 
   return {
     url: pathWithQuery,
@@ -113,14 +121,41 @@ async function convertTanStackStartToUniversal(
   };
 }
 
-function universalToResponse(res: UniversalResponse): Response {
+function universalToResponse(res: UniversalResponse, config: StudioConfig): Response {
   const headers = new Headers(res.headers);
   res.setCookies?.forEach((cookie) => {
     headers.append("Set-Cookie", cookie);
   });
 
-  return new Response(res.body, {
+  let body = res.body;
+  if (
+    typeof body === "string" &&
+    headers.get("Content-Type")?.toLowerCase().includes("text/html")
+  ) {
+    body = rewriteStaticAssetUrls(body, config.basePath || "/api/studio");
+  }
+
+  return new Response(body, {
     status: res.status,
     headers,
+  });
+}
+
+/**
+ * Nitro can treat nested URLs ending in .js/.css as public files before a
+ * TanStack Start splat route gets a chance to handle them. Keep Studio assets
+ * on the exact server-route URL and carry the requested file in the query.
+ */
+function rewriteStaticAssetUrls(html: string, basePath: string): string {
+  const normalizedBasePath = basePath.endsWith("/") ? basePath.slice(0, -1) : basePath;
+  const escapedBasePath = normalizedBasePath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const assetUrlPattern = new RegExp(
+    `((?:href|src)=["'])${escapedBasePath}(/(?:assets/[^"'?#]+|vite\\.svg|favicon\\.svg|logo\\.png))(["'])`,
+    "g",
+  );
+
+  return html.replace(assetUrlPattern, (_match, prefix, assetPath, suffix) => {
+    const query = new URLSearchParams({ [STATIC_ASSET_QUERY_PARAM]: assetPath });
+    return `${prefix}${normalizedBasePath}?${query.toString()}${suffix}`;
   });
 }

--- a/tests/tanstack-start.test.ts
+++ b/tests/tanstack-start.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { UniversalRequest } from "../src/types/handler";
+
+const handleStudioRequest = vi.fn();
+
+vi.mock("../src/core/handler.js", () => ({
+  handleStudioRequest,
+}));
+
+vi.mock("../src/utils/hook-injector.js", () => ({
+  injectEventHooks: vi.fn(),
+  injectLastSeenAtHooks: vi.fn(),
+}));
+
+const { betterAuthStudio } = await import("../src/adapters/tanstack-start");
+
+describe("TanStack Start adapter", () => {
+  beforeEach(() => {
+    handleStudioRequest.mockReset();
+  });
+
+  it("routes static assets through the exact studio route", async () => {
+    handleStudioRequest.mockResolvedValue({
+      status: 200,
+      headers: { "Content-Type": "text/html" },
+      body: [
+        '<script src="/api/studio/assets/main.js"></script>',
+        '<link href="/api/studio/assets/main.css" rel="stylesheet">',
+        '<link href="/api/studio/logo.png" rel="icon">',
+      ].join(""),
+    });
+
+    const handler = betterAuthStudio({ auth: {}, basePath: "/api/studio" });
+    const response = await handler({
+      request: new Request("http://localhost:3000/api/studio"),
+    });
+    const html = await response.text();
+
+    expect(html).toContain("/api/studio?__better_auth_studio_asset=%2Fassets%2Fmain.js");
+    expect(html).toContain("/api/studio?__better_auth_studio_asset=%2Fassets%2Fmain.css");
+    expect(html).toContain("/api/studio?__better_auth_studio_asset=%2Flogo.png");
+  });
+
+  it("converts a static asset query back to its public file path", async () => {
+    handleStudioRequest.mockResolvedValue({
+      status: 200,
+      headers: { "Content-Type": "text/css" },
+      body: "body{}",
+    });
+
+    const handler = betterAuthStudio({ auth: {}, basePath: "/api/studio" });
+    await handler({
+      request: new Request(
+        "http://localhost:3000/api/studio?__better_auth_studio_asset=%2Fassets%2Fmain.css",
+      ),
+    });
+
+    expect(handleStudioRequest).toHaveBeenCalledOnce();
+    const request = handleStudioRequest.mock.calls[0][0] as UniversalRequest;
+    expect(request.url).toBe("/assets/main.css");
+  });
+
+  it("does not accept arbitrary paths through the asset query", async () => {
+    handleStudioRequest.mockResolvedValue({
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+      body: "{}",
+    });
+
+    const handler = betterAuthStudio({ auth: {}, basePath: "/api/studio" });
+    await handler({
+      request: new Request(
+        "http://localhost:3000/api/studio?__better_auth_studio_asset=%2Fapi%2Fusers",
+      ),
+    });
+
+    const request = handleStudioRequest.mock.calls[0][0] as UniversalRequest;
+    expect(request.url).toBe("/");
+  });
+});


### PR DESCRIPTION
## Summary

- route TanStack Studio static assets through the exact Studio server route
- decode and validate the requested asset path inside the adapter
- add regression coverage for JavaScript, CSS, image assets, and rejected arbitrary paths
- update the compiled TanStack adapter output

## Root cause

In some TanStack Start monorepos using Nitro, nested file-like URLs such as `/api/studio/assets/*.js` and `/api/studio/assets/*.css` are intercepted as public files before the TanStack splat server route can handle them. This returns a 404 even though the Studio HTML itself loads.

The adapter now carries static asset paths in a reserved query parameter on the exact `/api/studio` route, avoiding Nitro's public-file interception while preserving normal Studio API routing.

## Validation

- `pnpm test --run` — 102 tests passed
- `pnpm type-check`
- `pnpm build`
- changed files pass oxlint and formatting checks

Fixes #116