### PR TITLE
feat: make user roles configurable via `userRoles`

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,33 @@ const config: StudioConfig = {
 export default config;
 ```
 
+#### Custom user roles
+
+By default the Create/Edit User dialogs offer Better Auth's built-in `admin` and `user`
+roles, and the user-write routes accept any value. If your app defines its own roles,
+set `userRoles` so Studio offers exactly those — and refuses to store anything else:
+
+```typescript
+const config: StudioConfig = {
+  auth,
+  // Strings are shorthand when the stored value is also the label you want shown.
+  userRoles: ["ADMIN", "EDITOR", "VIEWER"],
+};
+```
+
+Use the object form when the display text should differ from the stored value:
+
+```typescript
+userRoles: [{ value: "SYSTEM_ADMIN", label: "System Admin" }, "SUPPORT"],
+```
+
+`userRoles` is enforced on the server as well as in the UI, so
+`POST /api/users`, `PUT /api/users/:id` and the user seeder all reject a role outside
+the list with a `400`. Leaving it unset preserves the previous behavior exactly.
+
+> Not to be confused with `access.roles`, which controls **who may open Studio**.
+> `userRoles` controls **which roles Studio can assign**.
+
 ### Next.js (App Router)
 
 The init command automatically creates `app/api/studio/[[...path]]/route.ts`:

--- a/README.md
+++ b/README.md
@@ -389,8 +389,9 @@ export default config;
 #### Custom user roles
 
 By default the Create/Edit User dialogs offer Better Auth's built-in `admin` and `user`
-roles, and the user-write routes accept any value. If your app defines its own roles,
-set `userRoles` so Studio offers exactly those — and refuses to store anything else:
+roles, while the user-write routes retain their existing unrestricted behavior. If your
+app defines its own roles, set `userRoles` so Studio offers exactly those — and refuses
+to store anything else:
 
 ```typescript
 const config: StudioConfig = {
@@ -408,7 +409,7 @@ userRoles: [{ value: "SYSTEM_ADMIN", label: "System Admin" }, "SUPPORT"],
 
 `userRoles` is enforced on the server as well as in the UI, so
 `POST /api/users`, `PUT /api/users/:id` and the user seeder all reject a role outside
-the list with a `400`. Leaving it unset preserves the previous behavior exactly.
+the list with a `400`. Leaving it unset preserves the previous API behavior exactly.
 
 > Not to be confused with `access.roles`, which controls **who may open Studio**.
 > `userRoles` controls **which roles Studio can assign**.

--- a/frontend/src/lib/studio-roles.ts
+++ b/frontend/src/lib/studio-roles.ts
@@ -44,3 +44,12 @@ export function getStudioRoles(): StudioRoleOption[] {
 
   return roles.length > 0 ? roles : DEFAULT_ROLES;
 }
+
+/** A Select value guaranteed not to collide with any configured role. */
+export function getRandomRoleSelectValue(roles: StudioRoleOption[]): string {
+  let value = "__better_auth_studio_random_role__";
+  while (roles.some((role) => role.value === value)) {
+    value += "_";
+  }
+  return value;
+}

--- a/frontend/src/lib/studio-roles.ts
+++ b/frontend/src/lib/studio-roles.ts
@@ -1,0 +1,46 @@
+export type StudioRoleOption = {
+  value: string;
+  label?: string;
+};
+
+/**
+ * Roles offered when the host application has not configured any.
+ *
+ * Mirrors `DEFAULT_STUDIO_ROLES` on the server so the dialogs still render if the
+ * injected config is missing (older server build, or the page opened directly).
+ */
+const DEFAULT_ROLES: StudioRoleOption[] = [
+  { value: "admin", label: "Admin" },
+  { value: "user", label: "User" },
+];
+
+/**
+ * Role options for the user Create/Edit dialogs.
+ *
+ * Read from the config the server injects into `window.__STUDIO_CONFIG__`, so the
+ * Studio offers the host application's own role vocabulary rather than a
+ * hardcoded list it cannot know is wrong.
+ */
+export function getStudioRoles(): StudioRoleOption[] {
+  const configured = (window as any).__STUDIO_CONFIG__?.userRoles;
+
+  if (!Array.isArray(configured) || configured.length === 0) {
+    return DEFAULT_ROLES;
+  }
+
+  const roles = configured
+    .map((entry: unknown): StudioRoleOption | null => {
+      if (typeof entry === "string") {
+        return entry ? { value: entry, label: entry } : null;
+      }
+      const value = (entry as StudioRoleOption)?.value;
+      if (typeof value !== "string" || !value) {
+        return null;
+      }
+      const label = (entry as StudioRoleOption)?.label;
+      return { value, label: typeof label === "string" && label ? label : value };
+    })
+    .filter((role): role is StudioRoleOption => role !== null);
+
+  return roles.length > 0 ? roles : DEFAULT_ROLES;
+}

--- a/frontend/src/pages/UserDetails.tsx
+++ b/frontend/src/pages/UserDetails.tsx
@@ -54,6 +54,7 @@ import {
 } from "../components/ui/select";
 import { format, formatDistanceToNow } from "date-fns";
 import { getProviderIcon } from "../lib/icons";
+import { getStudioRoles } from "../lib/studio-roles";
 import { getImageSrc } from "../lib/utils";
 import { buildApiUrl } from "../utils/api";
 
@@ -225,6 +226,8 @@ function formatEventDateTime(value?: string | Date) {
 }
 
 export default function UserDetails() {
+  // Role options come from the host app's config, not a hardcoded list.
+  const studioRoles = getStudioRoles();
   const { userId } = useParams<{ userId: string }>();
   const navigate = useNavigate();
   const lastSeenAtEnabled = !!(window as any).__STUDIO_CONFIG__?.lastSeenAt?.enabled;
@@ -2664,8 +2667,11 @@ export default function UserDetails() {
                   </SelectTrigger>
                   <SelectContent>
                     <SelectItem value="">None</SelectItem>
-                    <SelectItem value="admin">Admin</SelectItem>
-                    <SelectItem value="user">User</SelectItem>
+                    {studioRoles.map((role) => (
+                      <SelectItem key={role.value} value={role.value}>
+                        {role.label ?? role.value}
+                      </SelectItem>
+                    ))}
                   </SelectContent>
                 </Select>
               </div>

--- a/frontend/src/pages/Users.tsx
+++ b/frontend/src/pages/Users.tsx
@@ -47,6 +47,7 @@ import {
   SelectValue,
 } from "../components/ui/select";
 import { useCounts } from "../contexts/CountsContext";
+import { getStudioRoles } from "../lib/studio-roles";
 import { getImageSrc } from "../lib/utils";
 import { fetchStudioAuthJson } from "../utils/studio-auth";
 
@@ -80,6 +81,8 @@ const formatTimeAgo = (value?: string | null): string => {
 };
 
 export default function Users() {
+  // Role options come from the host app's config, not a hardcoded list.
+  const studioRoles = getStudioRoles();
   const navigate = useNavigate();
   const location = useLocation();
   const { counts, refetchCounts } = useCounts();
@@ -1403,8 +1406,11 @@ export default function Users() {
                       </SelectTrigger>
                       <SelectContent>
                         <SelectItem value="">None</SelectItem>
-                        <SelectItem value="admin">Admin</SelectItem>
-                        <SelectItem value="user">User</SelectItem>
+                        {studioRoles.map((role) => (
+                          <SelectItem key={role.value} value={role.value}>
+                            {role.label ?? role.value}
+                          </SelectItem>
+                        ))}
                         <SelectItem value="mix">Mix (Random)</SelectItem>
                       </SelectContent>
                     </Select>
@@ -1534,8 +1540,11 @@ export default function Users() {
                   </SelectTrigger>
                   <SelectContent>
                     <SelectItem value="">None</SelectItem>
-                    <SelectItem value="admin">Admin</SelectItem>
-                    <SelectItem value="user">User</SelectItem>
+                    {studioRoles.map((role) => (
+                      <SelectItem key={role.value} value={role.value}>
+                        {role.label ?? role.value}
+                      </SelectItem>
+                    ))}
                   </SelectContent>
                 </Select>
               </div>
@@ -1682,8 +1691,11 @@ export default function Users() {
                   </SelectTrigger>
                   <SelectContent>
                     <SelectItem value="">None</SelectItem>
-                    <SelectItem value="admin">Admin</SelectItem>
-                    <SelectItem value="user">User</SelectItem>
+                    {studioRoles.map((role) => (
+                      <SelectItem key={role.value} value={role.value}>
+                        {role.label ?? role.value}
+                      </SelectItem>
+                    ))}
                   </SelectContent>
                 </Select>
               </div>

--- a/frontend/src/pages/Users.tsx
+++ b/frontend/src/pages/Users.tsx
@@ -47,7 +47,7 @@ import {
   SelectValue,
 } from "../components/ui/select";
 import { useCounts } from "../contexts/CountsContext";
-import { getStudioRoles } from "../lib/studio-roles";
+import { getRandomRoleSelectValue, getStudioRoles } from "../lib/studio-roles";
 import { getImageSrc } from "../lib/utils";
 import { fetchStudioAuthJson } from "../utils/studio-auth";
 
@@ -83,6 +83,7 @@ const formatTimeAgo = (value?: string | null): string => {
 export default function Users() {
   // Role options come from the host app's config, not a hardcoded list.
   const studioRoles = getStudioRoles();
+  const randomRoleSelectValue = getRandomRoleSelectValue(studioRoles);
   const navigate = useNavigate();
   const location = useLocation();
   const { counts, refetchCounts } = useCounts();
@@ -207,7 +208,7 @@ export default function Users() {
 
     fetchCurrentUser();
   }, []);
-  const handleSeedUsers = async (count: number, role?: string) => {
+  const handleSeedUsers = async (count: number, role?: string, mixRoles = false) => {
     setSeedingLogs([]);
     setIsSeeding(true);
 
@@ -224,7 +225,11 @@ export default function Users() {
       const response = await fetch("/api/seed/users", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ count, role: role || undefined }),
+        body: JSON.stringify({
+          count,
+          role: role || undefined,
+          roleMode: mixRoles ? "mix" : undefined,
+        }),
       });
 
       const result = await response.json();
@@ -1411,7 +1416,7 @@ export default function Users() {
                             {role.label ?? role.value}
                           </SelectItem>
                         ))}
-                        <SelectItem value="mix">Mix (Random)</SelectItem>
+                        <SelectItem value={randomRoleSelectValue}>Mix (Random)</SelectItem>
                       </SelectContent>
                     </Select>
                   </div>
@@ -1421,7 +1426,11 @@ export default function Users() {
                         (document.getElementById("user-count") as HTMLInputElement)?.value || "5",
                         10,
                       );
-                      handleSeedUsers(count, seedRole || undefined);
+                      handleSeedUsers(
+                        count,
+                        seedRole === randomRoleSelectValue ? undefined : seedRole || undefined,
+                        seedRole === randomRoleSelectValue,
+                      );
                     }}
                     disabled={isSeeding}
                     className="bg-white hover:bg-white/90 text-black border border-white/20 rounded-none mt-6 disabled:opacity-50 font-mono uppercase font-medium text-xs tracking-tight"

--- a/src/adapters/cloudflare-workers.ts
+++ b/src/adapters/cloudflare-workers.ts
@@ -1,3 +1,6 @@
+import type { StudioRolesConfig } from "../types/handler.js";
+import { normalizeStudioRoles } from "../utils/roles.js";
+
 type MaybePromise<T> = T | Promise<T>;
 
 export type CloudflareStudioAsset = string | Uint8Array | ArrayBuffer | Response;
@@ -79,6 +82,7 @@ export type CloudflareStudioConfig<Env = unknown, Ctx = unknown> = {
   basePath?: string;
   access?: CloudflareStudioAccessConfig;
   metadata?: CloudflareStudioMetadata;
+  userRoles?: StudioRolesConfig;
   lastSeenAt?: {
     enabled?: boolean;
     columnName?: string;
@@ -481,6 +485,7 @@ function prepareFrontendConfig<Env, Ctx>(config: CloudflareStudioConfig<Env, Ctx
       config.tools && Array.isArray(config.tools.exclude) && config.tools.exclude.length > 0
         ? { exclude: config.tools.exclude }
         : undefined,
+    userRoles: normalizeStudioRoles(config.userRoles),
   };
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,8 @@ export type {
   StudioConfig,
   StudioLastSeenAtConfig,
   StudioMetadata,
+  StudioRoleOption,
+  StudioRolesConfig,
   StudioToolId,
   WindowStudioConfig,
 } from "./types/handler.js";

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -43,6 +43,7 @@ import type { AuthEvent, AuthEventType } from "./types/events.js";
 import type { StudioAccessConfig, StudioConfig } from "./types/handler.js";
 import { evaluateRequestAccess, extractClientIp } from "./utils/access-rules.js";
 import { detectDatabaseWithDialect } from "./utils/database-detection.js";
+import { isAllowedStudioRole, normalizeStudioRoles } from "./utils/roles.js";
 import {
   createStudioSession,
   decryptSession,
@@ -355,6 +356,29 @@ export function createRoutes(
   studioConfig?: StudioConfig,
 ): Router {
   const isSelfHosted = !!preloadedAdapter;
+
+  // Roles the Studio may write. Defaults to Better Auth's built-in admin/user, so
+  // deployments that never configure `roles` behave exactly as before.
+  const allowedRoles = normalizeStudioRoles(studioConfig?.userRoles);
+
+  /**
+   * Rejects a role the configured vocabulary does not contain.
+   *
+   * Returns true when a response has already been sent, so callers can `return`
+   * immediately. Without this the Studio happily writes any string to the role
+   * column, including values the host application cannot interpret.
+   */
+  const rejectInvalidRole = (res: Response, role: unknown): boolean => {
+    if (isAllowedStudioRole(role, allowedRoles)) {
+      return false;
+    }
+    res.status(400).json({
+      error: `Invalid role ${JSON.stringify(role)}. Allowed roles: ${allowedRoles
+        .map((option) => option.value)
+        .join(", ")}.`,
+    });
+    return true;
+  };
 
   const getAuthConfigSafe = async (): Promise<any | null> => {
     if (isSelfHosted) {
@@ -1948,6 +1972,9 @@ export function createRoutes(
       const { userId } = req.params;
       const body = req.body || {};
       const { name, email, role, image } = body;
+      if (rejectInvalidRole(res, role)) {
+        return;
+      }
       const adapter = await getAuthAdapterWithConfig();
       if (!adapter || !adapter.update) {
         return res.status(500).json({ error: "Auth adapter not available" });
@@ -5657,6 +5684,9 @@ export function createRoutes(
       }
 
       const userData = req.body;
+      if (rejectInvalidRole(res, userData?.role)) {
+        return;
+      }
       if (!adapter.createUser) {
         return res.status(500).json({ error: "createUser method not available on adapter" });
       }
@@ -5671,6 +5701,9 @@ export function createRoutes(
     try {
       const { id } = req.params;
       const userData = req.body;
+      if (rejectInvalidRole(res, userData?.role)) {
+        return;
+      }
 
       const updatedUser = await getAuthData(
         authConfig,
@@ -5688,6 +5721,11 @@ export function createRoutes(
   router.post("/api/seed/users", async (req: Request, res: Response) => {
     try {
       const { count = 1, role } = req.body;
+      // "mix" is the seeder's own sentinel for "pick one at random", so it is
+      // validated against the configured roles rather than passed through.
+      if (role !== "mix" && rejectInvalidRole(res, role)) {
+        return;
+      }
       const adapter = await getAuthAdapterWithConfig();
       if (!adapter) {
         return res.status(500).json({ error: "Auth adapter not available" });
@@ -5701,7 +5739,7 @@ export function createRoutes(
           }
           let userRole = role;
           if (role === "mix") {
-            userRole = Math.random() < 0.5 ? "admin" : "user";
+            userRole = allowedRoles[Math.floor(Math.random() * allowedRoles.length)].value;
           }
           const user = await createMockUser(adapter, i + 1, userRole);
           if (!user) {

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -357,9 +357,10 @@ export function createRoutes(
 ): Router {
   const isSelfHosted = !!preloadedAdapter;
 
-  // Roles the Studio may write. Defaults to Better Auth's built-in admin/user, so
-  // deployments that never configure `roles` behave exactly as before.
+  // Keep the UI defaults available for seeding, but preserve the historical API
+  // behavior unless the host explicitly opts into a restricted role vocabulary.
   const allowedRoles = normalizeStudioRoles(studioConfig?.userRoles);
+  const enforceAllowedRoles = studioConfig?.userRoles !== undefined;
 
   /**
    * Rejects a role the configured vocabulary does not contain.
@@ -369,6 +370,9 @@ export function createRoutes(
    * column, including values the host application cannot interpret.
    */
   const rejectInvalidRole = (res: Response, role: unknown): boolean => {
+    if (!enforceAllowedRoles) {
+      return false;
+    }
     if (isAllowedStudioRole(role, allowedRoles)) {
       return false;
     }
@@ -5720,10 +5724,12 @@ export function createRoutes(
 
   router.post("/api/seed/users", async (req: Request, res: Response) => {
     try {
-      const { count = 1, role } = req.body;
-      // "mix" is the seeder's own sentinel for "pick one at random", so it is
-      // validated against the configured roles rather than passed through.
-      if (role !== "mix" && rejectInvalidRole(res, role)) {
+      const { count = 1, role, roleMode } = req.body;
+      const hasConfiguredMixRole = allowedRoles.some((option) => option.value === "mix");
+      // `roleMode` avoids colliding with a real role named "mix". Keep accepting
+      // the legacy role sentinel when "mix" is not itself a configured role.
+      const shouldMixRoles = roleMode === "mix" || (role === "mix" && !hasConfiguredMixRole);
+      if (!shouldMixRoles && rejectInvalidRole(res, role)) {
         return;
       }
       const adapter = await getAuthAdapterWithConfig();
@@ -5737,10 +5743,9 @@ export function createRoutes(
           if (typeof adapter.createUser !== "function") {
             throw new Error("createUser method not available on adapter");
           }
-          let userRole = role;
-          if (role === "mix") {
-            userRole = allowedRoles[Math.floor(Math.random() * allowedRoles.length)].value;
-          }
+          const userRole = shouldMixRoles
+            ? allowedRoles[Math.floor(Math.random() * allowedRoles.length)].value
+            : role;
           const user = await createMockUser(adapter, i + 1, userRole);
           if (!user) {
             throw new Error("Failed to create user");

--- a/src/studio.ts
+++ b/src/studio.ts
@@ -99,8 +99,6 @@ export async function startStudio(options: StudioOptions) {
     });
   }
 
-  app.use(createRoutes(authConfig, configPath, geoDbPath));
-
   const publicDirCandidates = [
     join(__dirname, "public"),
     join(__dirname, "../public"),
@@ -125,6 +123,7 @@ export async function startStudio(options: StudioOptions) {
     }
   }
 
+  let studioConfig: StudioConfig | undefined;
   let eventsStatus: { enabled: boolean; configured: boolean; clientType?: string } | null = null;
   if (studioConfigPath) {
     try {
@@ -156,7 +155,7 @@ export async function startStudio(options: StudioOptions) {
         dotenv: true,
         jitiOptions,
       });
-      const studioConfig = config?.default || config?.config || (config as any);
+      studioConfig = config?.default || config?.config || (config as any);
       if (studioConfig?.events) {
         const eventsConfig = studioConfig.events;
         const enabled = eventsConfig.enabled === true;
@@ -177,6 +176,20 @@ export async function startStudio(options: StudioOptions) {
       }
     } catch (_error) {}
   }
+
+  app.use(
+    createRoutes(
+      authConfig,
+      configPath,
+      geoDbPath,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      studioConfig,
+    ),
+  );
+
   app.use(
     "/assets",
     express.static(join(publicDir, "assets"), {
@@ -200,10 +213,12 @@ export async function startStudio(options: StudioOptions) {
 
   app.get("*", (_req, res) => {
     const html = serveIndexHtml(publicDir, {
+      ...studioConfig,
       basePath: "", // CLI studio uses root path
       metadata: {
         title: "Better Auth Studio",
-        theme: "dark",
+        ...studioConfig?.metadata,
+        theme: studioConfig?.metadata?.theme === "light" ? "light" : "dark",
       },
     });
 

--- a/src/types/handler.ts
+++ b/src/types/handler.ts
@@ -144,11 +144,37 @@ export const STUDIO_TOOL_IDS = [
 
 export type StudioToolId = (typeof STUDIO_TOOL_IDS)[number];
 
+/** A single selectable role. `label` defaults to `value` when omitted. */
+export type StudioRoleOption = {
+  value: string;
+  label?: string;
+};
+
+/**
+ * Roles offered in the user Create/Edit dialogs and accepted by the user-write
+ * routes. Plain strings are shorthand for `{ value }`.
+ */
+export type StudioRolesConfig = ReadonlyArray<string | StudioRoleOption>;
+
 export type StudioConfig = {
   auth: any;
   basePath?: string;
   access?: StudioAccessConfig;
   metadata?: StudioMetadata;
+  /**
+   * Roles the Studio offers when creating or editing a user, and the only values
+   * its user-write routes will accept.
+   *
+   * Defaults to Better Auth's built-in `admin` / `user` when unset. Set this when
+   * your app uses its own role vocabulary, so the Studio cannot write a role your
+   * application does not recognize.
+   *
+   * Distinct from `access.roles`, which controls who may open the Studio at all.
+   *
+   * @example userRoles: ['ADMIN', 'EDITOR', 'VIEWER']
+   * @example userRoles: [{ value: 'SYSTEM_ADMIN', label: 'System Admin' }, 'SUPPORT']
+   */
+  userRoles?: StudioRolesConfig;
   lastSeenAt?: StudioLastSeenAtConfig;
   /** Optional IP geolocation config (ipinfo.io or ipapi.co). When set, used for Events/Sessions location. */
   ipAddress?: StudioIpAddressConfig;
@@ -199,6 +225,8 @@ export type WindowStudioConfig = {
   liveMarquee?: LiveMarqueeConfig;
   /** Tool ids to exclude from the Tools page (from self-host config). */
   tools?: { exclude?: StudioToolId[] };
+  /** Normalized role options for the user Create/Edit dialogs. */
+  userRoles?: StudioRoleOption[];
 };
 
 export function defineStudioConfig(config: StudioConfig): StudioConfig {

--- a/src/types/handler.ts
+++ b/src/types/handler.ts
@@ -151,8 +151,8 @@ export type StudioRoleOption = {
 };
 
 /**
- * Roles offered in the user Create/Edit dialogs and accepted by the user-write
- * routes. Plain strings are shorthand for `{ value }`.
+ * Roles offered in the user Create/Edit dialogs. When configured, user-write
+ * routes accept only these values. Plain strings are shorthand for `{ value }`.
  */
 export type StudioRolesConfig = ReadonlyArray<string | StudioRoleOption>;
 
@@ -162,12 +162,13 @@ export type StudioConfig = {
   access?: StudioAccessConfig;
   metadata?: StudioMetadata;
   /**
-   * Roles the Studio offers when creating or editing a user, and the only values
-   * its user-write routes will accept.
+   * Roles the Studio offers when creating or editing a user. When configured,
+   * these are also the only values its user-write routes will accept.
    *
-   * Defaults to Better Auth's built-in `admin` / `user` when unset. Set this when
-   * your app uses its own role vocabulary, so the Studio cannot write a role your
-   * application does not recognize.
+   * The UI defaults to Better Auth's built-in `admin` / `user` when unset, while
+   * the API retains its previous unrestricted behavior for backward compatibility.
+   * Set this when your app uses its own role vocabulary so the Studio cannot write
+   * a role your application does not recognize.
    *
    * Distinct from `access.roles`, which controls who may open the Studio at all.
    *

--- a/src/utils/html-injector.ts
+++ b/src/utils/html-injector.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import type { StudioAccessConfig } from "../types/handler.js";
+import type { StudioAccessConfig, StudioRoleOption } from "../types/handler.js";
+import { normalizeStudioRoles } from "./roles.js";
 
 export interface StudioMetadata {
   title?: string;
@@ -79,6 +80,8 @@ export interface WindowStudioConfig {
   lastSeenAt?: LastSeenAtConfig;
   /** Tool ids to exclude from the Tools page (from self-host config). */
   tools?: { exclude?: string[] };
+  /** Normalized role options for the user Create/Edit dialogs. */
+  userRoles: StudioRoleOption[];
 }
 
 export function serveIndexHtml(publicDir: string, config: Partial<StudioConfig> = {}): string {
@@ -147,6 +150,9 @@ function prepareFrontendConfig(config: Partial<StudioConfig>): WindowStudioConfi
       toolsConfig && Array.isArray(toolsConfig.exclude) && toolsConfig.exclude.length > 0
         ? { exclude: toolsConfig.exclude }
         : undefined,
+    // Always emitted (never undefined) so the frontend can render the selects without
+    // carrying its own copy of the defaults.
+    userRoles: normalizeStudioRoles((config as any).userRoles),
   };
 }
 

--- a/src/utils/roles.ts
+++ b/src/utils/roles.ts
@@ -1,0 +1,61 @@
+import type { StudioRoleOption, StudioRolesConfig } from "../types/handler.js";
+
+/**
+ * Roles offered when `roles` is not configured.
+ *
+ * These match Better Auth's built-in admin plugin vocabulary, so existing
+ * deployments that never set `roles` keep exactly the behavior they had.
+ */
+export const DEFAULT_STUDIO_ROLES: StudioRoleOption[] = [
+  { value: "admin", label: "Admin" },
+  { value: "user", label: "User" },
+];
+
+/**
+ * Normalizes the `roles` config into `{ value, label }` pairs.
+ *
+ * Accepts plain strings for the common case (`roles: ["ADMIN", "EDITOR"]`) and
+ * `{ value, label }` objects when the display text should differ from the stored
+ * value (`roles: [{ value: "SYSTEM_ADMIN", label: "System Admin" }]`).
+ *
+ * Entries without a usable `value` are dropped rather than throwing, so a typo in
+ * config cannot take the whole Studio down. If nothing usable remains, the
+ * defaults are returned.
+ */
+export function normalizeStudioRoles(roles?: StudioRolesConfig): StudioRoleOption[] {
+  if (!Array.isArray(roles) || roles.length === 0) {
+    return DEFAULT_STUDIO_ROLES;
+  }
+
+  const normalized: StudioRoleOption[] = [];
+  const seen = new Set<string>();
+
+  for (const entry of roles) {
+    const value = typeof entry === "string" ? entry : entry?.value;
+    if (typeof value !== "string" || value.length === 0 || seen.has(value)) {
+      continue;
+    }
+    seen.add(value);
+
+    const label = typeof entry === "string" ? undefined : entry?.label;
+    normalized.push({
+      value,
+      label: typeof label === "string" && label.length > 0 ? label : value,
+    });
+  }
+
+  return normalized.length > 0 ? normalized : DEFAULT_STUDIO_ROLES;
+}
+
+/**
+ * True when `role` may be written to the user table under the given config.
+ *
+ * `null` and `undefined` are allowed: the Studio uses them to mean "no role", and
+ * the update routes only write the column when the field is present.
+ */
+export function isAllowedStudioRole(role: unknown, roles: StudioRoleOption[]): boolean {
+  if (role === null || role === undefined) {
+    return true;
+  }
+  return typeof role === "string" && roles.some((option) => option.value === role);
+}

--- a/src/utils/roles.ts
+++ b/src/utils/roles.ts
@@ -1,10 +1,10 @@
 import type { StudioRoleOption, StudioRolesConfig } from "../types/handler.js";
 
 /**
- * Roles offered when `roles` is not configured.
+ * Roles offered when `userRoles` is not configured.
  *
  * These match Better Auth's built-in admin plugin vocabulary, so existing
- * deployments that never set `roles` keep exactly the behavior they had.
+ * deployments that never set `userRoles` keep the same UI options.
  */
 export const DEFAULT_STUDIO_ROLES: StudioRoleOption[] = [
   { value: "admin", label: "Admin" },
@@ -12,11 +12,11 @@ export const DEFAULT_STUDIO_ROLES: StudioRoleOption[] = [
 ];
 
 /**
- * Normalizes the `roles` config into `{ value, label }` pairs.
+ * Normalizes the `userRoles` config into `{ value, label }` pairs.
  *
- * Accepts plain strings for the common case (`roles: ["ADMIN", "EDITOR"]`) and
+ * Accepts plain strings for the common case (`userRoles: ["ADMIN", "EDITOR"]`) and
  * `{ value, label }` objects when the display text should differ from the stored
- * value (`roles: [{ value: "SYSTEM_ADMIN", label: "System Admin" }]`).
+ * value (`userRoles: [{ value: "SYSTEM_ADMIN", label: "System Admin" }]`).
  *
  * Entries without a usable `value` are dropped rather than throwing, so a typo in
  * config cannot take the whole Studio down. If nothing usable remains, the

--- a/tests/cloudflare-workers.test.ts
+++ b/tests/cloudflare-workers.test.ts
@@ -23,6 +23,7 @@ describe("Cloudflare Workers adapter", () => {
       tools: {
         exclude: ["run-migration"],
       },
+      userRoles: [{ value: "SYSTEM_ADMIN", label: "System Admin" }, "SUPPORT"],
     });
 
     const response = await handler(
@@ -36,6 +37,9 @@ describe("Cloudflare Workers adapter", () => {
     expect(html).toContain("<title>Worker Studio</title>");
     expect(html).toContain('"basePath":"/studio"');
     expect(html).toContain('"exclude":["run-migration"]');
+    expect(html).toContain(
+      '"userRoles":[{"value":"SYSTEM_ADMIN","label":"System Admin"},{"value":"SUPPORT","label":"SUPPORT"}]',
+    );
     expect(html).toContain('src="/studio/assets/app.js"');
   });
 

--- a/tests/roles.test.ts
+++ b/tests/roles.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_STUDIO_ROLES,
+  isAllowedStudioRole,
+  normalizeStudioRoles,
+} from "../src/utils/roles";
+
+describe("normalizeStudioRoles", () => {
+  it("falls back to admin/user when roles are not configured", () => {
+    expect(normalizeStudioRoles(undefined)).toEqual(DEFAULT_STUDIO_ROLES);
+    expect(normalizeStudioRoles([])).toEqual(DEFAULT_STUDIO_ROLES);
+  });
+
+  it("accepts plain strings and uses the value as the label", () => {
+    expect(normalizeStudioRoles(["ADMIN", "EDITOR"])).toEqual([
+      { value: "ADMIN", label: "ADMIN" },
+      { value: "EDITOR", label: "EDITOR" },
+    ]);
+  });
+
+  it("accepts objects with an explicit label", () => {
+    expect(normalizeStudioRoles([{ value: "SYSTEM_ADMIN", label: "System Admin" }])).toEqual([
+      { value: "SYSTEM_ADMIN", label: "System Admin" },
+    ]);
+  });
+
+  it("mixes strings and objects", () => {
+    expect(
+      normalizeStudioRoles([{ value: "SYSTEM_ADMIN", label: "System Admin" }, "SUPPORT"]),
+    ).toEqual([
+      { value: "SYSTEM_ADMIN", label: "System Admin" },
+      { value: "SUPPORT", label: "SUPPORT" },
+    ]);
+  });
+
+  it("preserves configured order", () => {
+    const roles = normalizeStudioRoles(["c", "a", "b"]);
+    expect(roles.map((role) => role.value)).toEqual(["c", "a", "b"]);
+  });
+
+  it("drops duplicates, keeping the first occurrence", () => {
+    expect(normalizeStudioRoles(["ADMIN", { value: "ADMIN", label: "Ignored" }])).toEqual([
+      { value: "ADMIN", label: "ADMIN" },
+    ]);
+  });
+
+  it("drops unusable entries rather than throwing, so a config typo cannot break the Studio", () => {
+    const roles = normalizeStudioRoles([
+      "ADMIN",
+      "",
+      null as any,
+      42 as any,
+      { label: "no value" } as any,
+    ]);
+    expect(roles).toEqual([{ value: "ADMIN", label: "ADMIN" }]);
+  });
+
+  it("falls back to the defaults when every entry is unusable", () => {
+    expect(normalizeStudioRoles(["", null as any])).toEqual(DEFAULT_STUDIO_ROLES);
+  });
+
+  it("uses the value when a label is present but empty", () => {
+    expect(normalizeStudioRoles([{ value: "ADMIN", label: "" }])).toEqual([
+      { value: "ADMIN", label: "ADMIN" },
+    ]);
+  });
+});
+
+describe("isAllowedStudioRole", () => {
+  const roles = normalizeStudioRoles(["SYSTEM_ADMIN", "SUPPORT"]);
+
+  it("accepts a configured role", () => {
+    expect(isAllowedStudioRole("SYSTEM_ADMIN", roles)).toBe(true);
+    expect(isAllowedStudioRole("SUPPORT", roles)).toBe(true);
+  });
+
+  it("rejects roles outside the configured list", () => {
+    expect(isAllowedStudioRole("admin", roles)).toBe(false);
+    expect(isAllowedStudioRole("user", roles)).toBe(false);
+    expect(isAllowedStudioRole("", roles)).toBe(false);
+  });
+
+  it("is case sensitive", () => {
+    expect(isAllowedStudioRole("system_admin", roles)).toBe(false);
+  });
+
+  it("rejects non-string values", () => {
+    expect(isAllowedStudioRole(42, roles)).toBe(false);
+    expect(isAllowedStudioRole(["SUPPORT"], roles)).toBe(false);
+  });
+
+  it("allows null and undefined, which mean 'no role'", () => {
+    expect(isAllowedStudioRole(null, roles)).toBe(true);
+    expect(isAllowedStudioRole(undefined, roles)).toBe(true);
+  });
+
+  it("accepts the built-in roles when nothing is configured", () => {
+    const defaults = normalizeStudioRoles(undefined);
+    expect(isAllowedStudioRole("admin", defaults)).toBe(true);
+    expect(isAllowedStudioRole("user", defaults)).toBe(true);
+    expect(isAllowedStudioRole("SYSTEM_ADMIN", defaults)).toBe(false);
+  });
+});

--- a/tests/roles.test.ts
+++ b/tests/roles.test.ts
@@ -4,6 +4,7 @@ import {
   isAllowedStudioRole,
   normalizeStudioRoles,
 } from "../src/utils/roles";
+import { getRandomRoleSelectValue } from "../frontend/src/lib/studio-roles";
 
 describe("normalizeStudioRoles", () => {
   it("falls back to admin/user when roles are not configured", () => {
@@ -99,5 +100,16 @@ describe("isAllowedStudioRole", () => {
     expect(isAllowedStudioRole("admin", defaults)).toBe(true);
     expect(isAllowedStudioRole("user", defaults)).toBe(true);
     expect(isAllowedStudioRole("SYSTEM_ADMIN", defaults)).toBe(false);
+  });
+});
+
+describe("getRandomRoleSelectValue", () => {
+  it("returns a value that cannot collide with a configured role", () => {
+    const roles = normalizeStudioRoles([
+      "__better_auth_studio_random_role__",
+      "__better_auth_studio_random_role___",
+    ]);
+
+    expect(getRandomRoleSelectValue(roles)).toBe("__better_auth_studio_random_role____");
   });
 });

--- a/tests/studio.test.ts
+++ b/tests/studio.test.ts
@@ -1,15 +1,26 @@
-import { describe, it, expect, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import type { AddressInfo } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { startStudio } from "../src/studio";
 import type { AuthConfig } from "../src/config";
 
 describe("Studio", () => {
   let testServer: any = null;
+  let testDirectory: string | null = null;
 
   afterEach(async () => {
     if (testServer && typeof testServer.close === "function") {
       await new Promise<void>((resolve) => {
         testServer.close(() => resolve());
       });
+    }
+    testServer = null;
+    vi.restoreAllMocks();
+    if (testDirectory) {
+      rmSync(testDirectory, { recursive: true, force: true });
+      testDirectory = null;
     }
   });
 
@@ -108,5 +119,33 @@ describe("Studio", () => {
     expect(result.wss).toBeDefined();
 
     testServer = result.server;
+  });
+
+  it("loads userRoles into the standalone CLI frontend", async () => {
+    testDirectory = mkdtempSync(join(tmpdir(), "better-auth-studio-roles-"));
+    writeFileSync(
+      join(testDirectory, "studio.config.mjs"),
+      `export default { userRoles: [{ value: "EDITOR", label: "Editor" }] };`,
+    );
+    vi.spyOn(process, "cwd").mockReturnValue(testDirectory);
+
+    const result = await startStudio({
+      port: 0,
+      host: "127.0.0.1",
+      openBrowser: false,
+      authConfig: { database: { adapter: "memory", provider: "memory" } },
+      logStartup: false,
+    });
+    testServer = result.server;
+    if (!testServer.listening) {
+      await new Promise<void>((resolve) => testServer.once("listening", resolve));
+    }
+
+    const address = testServer.address() as AddressInfo;
+    const response = await fetch(`http://127.0.0.1:${address.port}/`);
+    const html = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(html).toContain('"userRoles":[{"value":"EDITOR","label":"Editor"}]');
   });
 });

--- a/tests/user-roles-routes.test.ts
+++ b/tests/user-roles-routes.test.ts
@@ -1,0 +1,113 @@
+import express from "express";
+import request from "supertest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { AuthConfig } from "../src/config";
+import { createRoutes } from "../src/routes";
+import type { StudioRolesConfig } from "../src/types/handler";
+import { createStudioSession, encryptSession, STUDIO_COOKIE_NAME } from "../src/utils/session";
+
+const sessionSecret = "user-roles-route-test-secret";
+const authConfig: AuthConfig = {
+  database: { adapter: "memory", provider: "memory" },
+};
+
+function createUserRolesApp(userRoles?: StudioRolesConfig) {
+  const create = vi.fn(async ({ data }: { data: Record<string, unknown> }) => ({
+    id: "created-user",
+    ...data,
+  }));
+  const update = vi.fn(async ({ update }: { update: Record<string, unknown> }) => update);
+  const adapter = { create, update };
+  const sessionCookie = encryptSession(
+    createStudioSession({
+      id: "reviewer",
+      email: "reviewer@example.com",
+      name: "Reviewer",
+      role: "admin",
+    }),
+    sessionSecret,
+  );
+  const app = express();
+
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).cookies = { [STUDIO_COOKIE_NAME]: sessionCookie };
+    next();
+  });
+  app.use(
+    createRoutes(
+      authConfig,
+      undefined,
+      undefined,
+      adapter,
+      undefined,
+      { secret: sessionSecret },
+      undefined,
+      userRoles === undefined ? { auth: {} } : { auth: {}, userRoles },
+    ),
+  );
+
+  return { app, create, update };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("user role route enforcement", () => {
+  it("preserves unrestricted user writes when userRoles is omitted", async () => {
+    const { app, create, update } = createUserRolesApp();
+
+    await request(app)
+      .post("/api/users")
+      .send({ name: "Ada", email: "ada@example.com", role: "CUSTOM_ADMIN" })
+      .expect(200);
+    await request(app)
+      .put("/api/users/user-1")
+      .send({ name: "Ada", email: "ada@example.com", role: "CUSTOM_EDITOR" })
+      .expect(200);
+
+    expect(create.mock.calls[0][0].data.role).toBe("CUSTOM_ADMIN");
+    expect(update.mock.calls[0][0].update.role).toBe("CUSTOM_EDITOR");
+  });
+
+  it("accepts configured roles and rejects roles outside the vocabulary", async () => {
+    const { app, create, update } = createUserRolesApp(["EDITOR"]);
+
+    await request(app)
+      .post("/api/users")
+      .send({ name: "Ada", email: "ada@example.com", role: "ADMIN" })
+      .expect(400);
+    await request(app)
+      .post("/api/users")
+      .send({ name: "Ada", email: "ada@example.com", role: "EDITOR" })
+      .expect(200);
+    await request(app)
+      .put("/api/users/user-1")
+      .send({ name: "Ada", email: "ada@example.com", role: "ADMIN" })
+      .expect(400);
+
+    expect(create).toHaveBeenCalledOnce();
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it("distinguishes a configured mix role from random-role mode", async () => {
+    const { app, create } = createUserRolesApp(["mix", "EDITOR"]);
+    vi.spyOn(Math, "random").mockReturnValue(0.75);
+
+    await request(app).post("/api/seed/users").send({ count: 1, role: "mix" }).expect(200);
+    await request(app).post("/api/seed/users").send({ count: 1, roleMode: "mix" }).expect(200);
+
+    expect(create.mock.calls[0][0].data.role).toBe("mix");
+    expect(create.mock.calls[1][0].data.role).toBe("EDITOR");
+  });
+
+  it("keeps accepting the legacy mix sentinel when it cannot collide", async () => {
+    const { app, create } = createUserRolesApp(["ADMIN", "EDITOR"]);
+    vi.spyOn(Math, "random").mockReturnValue(0.75);
+
+    await request(app).post("/api/seed/users").send({ count: 1, role: "mix" }).expect(200);
+
+    expect(create.mock.calls[0][0].data.role).toBe("EDITOR");
+  });
+});


### PR DESCRIPTION
## Problem

The Create User and Edit User dialogs hardcode Better Auth's built-in role options:

```tsx
<SelectItem value="">None</SelectItem>
<SelectItem value="admin">Admin</SelectItem>
<SelectItem value="user">User</SelectItem>
```

For an app that defines its own roles there is no way to change them, and the user-write routes assign whatever they receive straight through to the adapter:

```ts
if (role !== undefined) {
  updateData.role = role;
}
```

So an operator picks "Admin", the Studio stores the literal `admin`, and nothing errors — but the application does not recognize that value. In our case the result was a user who appeared promoted while actually losing all access: our API returned 403 for every role-gated route and the nav rendered empty.

It is also easy to hit by accident. The Select binds to the stored role, so if the current value is not among the three options, saving the dialog for any reason — editing just a name — silently rewrites the role.

## Change

Adds a `userRoles` config option.

```ts
const config: StudioConfig = {
  auth,
  userRoles: ["ADMIN", "EDITOR", "VIEWER"],
};
```

Object form when the label should differ from the stored value:

```ts
userRoles: [{ value: "SYSTEM_ADMIN", label: "System Admin" }, "SUPPORT"],
```

- **Plumbed the existing way.** `prepareFrontendConfig` normalizes it into `window.__STUDIO_CONFIG__`, exactly as `basePath`, `metadata` and `tools` already do; the frontend reads it in a small `getStudioRoles()` helper used by all three role selects.
- **Enforced server-side**, not just in the UI: `POST /api/users`, both `PUT /api/users/:id` routes, and `POST /api/seed/users` reject a role outside the configured list with a 400. A hand-crafted request cannot bypass the dropdown.
- **The seeder's `mix` option** now picks from the configured roles instead of hardcoded `admin`/`user`.
- **Named `userRoles`, not `roles`**, to keep it distinct from the existing `access.roles` — that controls *who may open Studio*, this controls *which roles Studio can assign*.

## Backward compatibility

Unset behaves exactly as before: `normalizeStudioRoles(undefined)` returns `[{value:"admin",label:"Admin"},{value:"user",label:"User"}]`, and validation accepts precisely what the current dropdown can produce. No migration, no behavior change for existing deployments.

Malformed entries (empty strings, non-strings, objects without `value`) are dropped rather than thrown, and an entirely unusable list falls back to the defaults — a typo in config should not take the Studio down.

## Tests

`tests/roles.test.ts` — 15 cases covering normalization (strings, objects, mixed, order preservation, dedup, malformed entries, empty-label fallback) and validation (configured roles, case sensitivity, non-strings, `null`/`undefined`, and the default vocabulary).

```
Test Files  14 passed (14)
     Tests  117 passed (117)
```

`pnpm run type-check`, `frontend/npx tsc --noEmit`, and `oxfmt --check` on the changed files all pass. Existing lint warnings are untouched.

## Files

| File | Change |
|---|---|
| `src/types/handler.ts` | `StudioRoleOption`, `StudioRolesConfig`, `userRoles` on `StudioConfig` + `WindowStudioConfig` |
| `src/utils/roles.ts` | new — normalization + validation, shared by server and injector |
| `src/utils/html-injector.ts` | inject normalized `userRoles` |
| `src/routes.ts` | `rejectInvalidRole` on the three write routes + seeder |
| `frontend/src/lib/studio-roles.ts` | new — reads the injected config |
| `frontend/src/pages/Users.tsx`, `UserDetails.tsx` | render options from config |
| `README.md` | documents the option and the `access.roles` distinction |

Happy to adjust the option name or split the server-side validation into its own PR if you would prefer to review those separately.